### PR TITLE
Name endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+0.2.4 (2016-12-27)
+------------------
+   * Squash exceptions during class enumeration, so your application can
+   still boot (and migrate, handle request, bust out the Melbourne
+   Shuffle, etc)
+
+0.2.3 (2016-12-26)
+------------------
+   * Work around Doctrine/MariaDB glitch where tilde characters end up
+   appended to column names
+   * Relax namespace requirements on controller trait - so you can use
+   POData-Laravel in other Laravel packages as well as directly
+
+0.2.2 (2016-12-25)
+------------------
+   * Allow metadata controller hookup to work - feed actual controllers,
+   not just names, into metadata controller provider
+
+0.2.1 (2016-12-24)
+------------------
+   * Stop preventing migrations when metadata trait enabled
+
+0.2.0 (2016-12-22)
+------------------
+   * Pick up stable version of POData
 
 0.1.1 (2016-11-04)
 ------------------

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "algo-web/podata": "dev-master",
         "doctrine/dbal": "^2.5",
         "php": ">=5.6.4",
-        "laravel/framework": ">=5.1"
+        "laravel/framework": ">=5.1",
+        "illuminate/http": ">=5.1"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -23,11 +23,6 @@ trait MetadataTrait
     ];
 
     /*
-     * Optional endpoint name to return if specified
-     */
-    protected $endpoint = null;
-
-    /*
      * Retrieve and assemble this model's metadata for OData packaging
      */
     public function metadata()
@@ -97,9 +92,11 @@ trait MetadataTrait
     public function getEndpointName()
     {
         if (!isset($this->endpoint)) {
-            return $this->getTable();
+            $bitter = get_class();
+            $name = substr($bitter, strrpos($bitter, '\\')+1);
+            return strtolower($name);
         }
-        return $this->endpoint;
+        return strtolower($this->endpoint);
     }
 
     /*

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -23,6 +23,11 @@ trait MetadataTrait
     ];
 
     /*
+     * Optional endpoint name to return if specified
+     */
+    protected $endpoint = null;
+
+    /*
      * Retrieve and assemble this model's metadata for OData packaging
      */
     public function metadata()
@@ -83,6 +88,18 @@ trait MetadataTrait
         }
 
         return $attribs;
+    }
+
+    /*
+     * Get the endpoint name being exposed
+     *
+     */
+    public function getEndpointName()
+    {
+        if (!isset($this->endpoint)) {
+            return $this->getTable();
+        }
+        return $this->endpoint;
     }
 
     /*

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -91,12 +91,14 @@ trait MetadataTrait
      */
     public function getEndpointName()
     {
-        if (!isset($this->endpoint)) {
+        $endpoint = isset($this->endpoint) ? $this->endpoint : null;
+
+        if (!isset($endpoint)) {
             $bitter = get_class();
             $name = substr($bitter, strrpos($bitter, '\\')+1);
             return strtolower($name);
         }
-        return strtolower($this->endpoint);
+        return strtolower($endpoint);
     }
 
     /*

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -64,9 +64,9 @@ class MetadataProvider extends ServiceProvider
         for ($i = 0; $i < $numEnds; $i++) {
             $bitter = $ends[$i];
             $fqModelName = $bitter;
-            $name = substr($bitter, strrpos($bitter, '\\')+1);
 
             $instance = new $fqModelName();
+            $name = $instance->getEndpointName();
             $metaSchema = $instance->getXmlSchema();
             // if for whatever reason we don't get an XML schema, move on to next entry and drop current one from
             // further processing

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -14,10 +14,13 @@ class TestModel extends Model
     }
     protected $metaArray;
 
-    public function __construct(array $meta = null)
+    public function __construct(array $meta = null, $endpoint = null)
     {
         if (isset($meta)) {
             $this->metaArray = $meta;
+        }
+        if (isset($endpoint)) {
+            $this->endpoint = $endpoint;
         }
         parent::__construct();
     }

--- a/tests/unit/Controllers/ODataControllerTest.php
+++ b/tests/unit/Controllers/ODataControllerTest.php
@@ -61,59 +61,6 @@ class ODataControllerTest extends TestCase
         );
     }
 
-
-    /**
-     * @covers \AlgoWeb\PODataLaravel\Controllers\ODataController::beforeFilter
-     * @todo   Implement testBeforeFilter().
-     */
-    public function testBeforeFilter()
-    {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
-    }
-
-
-    /**
-     * @covers \AlgoWeb\PODataLaravel\Controllers\ODataController::afterFilter
-     * @todo   Implement testAfterFilter().
-     */
-    public function testAfterFilter()
-    {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
-    }
-
-
-    /**
-     * @covers \AlgoWeb\PODataLaravel\Controllers\ODataController::forgetBeforeFilter
-     * @todo   Implement testForgetBeforeFilter().
-     */
-    public function testForgetBeforeFilter()
-    {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
-    }
-
-
-    /**
-     * @covers \AlgoWeb\PODataLaravel\Controllers\ODataController::forgetAfterFilter
-     * @todo   Implement testForgetAfterFilter().
-     */
-    public function testForgetAfterFilter()
-    {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
-    }
-
-
     /**
      * @covers \AlgoWeb\PODataLaravel\Controllers\ODataController::getMiddleware
      * @todo   Implement testGetMiddleware().
@@ -125,33 +72,6 @@ class ODataControllerTest extends TestCase
             'This test has not been implemented yet.'
         );
     }
-
-
-    /**
-     * @covers \AlgoWeb\PODataLaravel\Controllers\ODataController::getBeforeFilters
-     * @todo   Implement testGetBeforeFilters().
-     */
-    public function testGetBeforeFilters()
-    {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
-    }
-
-
-    /**
-     * @covers \AlgoWeb\PODataLaravel\Controllers\ODataController::getAfterFilters
-     * @todo   Implement testGetAfterFilters().
-     */
-    public function testGetAfterFilters()
-    {
-        // Remove the following lines when you implement this test.
-        $this->markTestIncomplete(
-            'This test has not been implemented yet.'
-        );
-    }
-
 
     /**
      * @covers \AlgoWeb\PODataLaravel\Controllers\ODataController::getRouter

--- a/tests/unit/Models/MetadataTraitTest.php
+++ b/tests/unit/Models/MetadataTraitTest.php
@@ -233,6 +233,7 @@ class MetadataTraitTest extends TestCase
         $foo = new TestModel($meta);
 
         $result = $foo->getXmlSchema();
+        $this->assertEquals('testmodel', $result->getName());
 
         $props = $result->getPropertiesDeclaredOnThisType();
         $this->assertEquals(2, count($props));
@@ -332,7 +333,7 @@ class MetadataTraitTest extends TestCase
 
     public function testGetEndpointSpecifiedName()
     {
-        $foo = new TestModel(null, 'endpoint');
+        $foo = new TestModel(null, 'EndPoint');
         $expected = 'endpoint';
         $actual = $foo->getEndpointName();
         $this->assertEquals($expected, $actual);

--- a/tests/unit/Models/MetadataTraitTest.php
+++ b/tests/unit/Models/MetadataTraitTest.php
@@ -320,4 +320,21 @@ class MetadataTraitTest extends TestCase
         $this->assertTrue(array_key_exists('morphTarget', $result['KnownPolyMorphSide']));
         $this->assertTrue(array_key_exists('morphTarget', $result['HasOne']));
     }
+
+    public function testGetDefaultEndpointName()
+    {
+        $foo = new TestModel();
+
+        $expected = 'testmodel';
+        $actual = $foo->getEndpointName();
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetEndpointSpecifiedName()
+    {
+        $foo = new TestModel(null, 'endpoint');
+        $expected = 'endpoint';
+        $actual = $foo->getEndpointName();
+        $this->assertEquals($expected, $actual);
+    }
 }


### PR DESCRIPTION
Allow default endpoint names (direct class name) to be optionally overridden, exactly same way as Laravel already allows in eloquent models $primaryKey property.