### PR TITLE
Passport support and custom migration table names

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,6 @@
             "tests/"
         ]
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -26,7 +26,7 @@ class MetadataProvider extends MetadataBaseProvider
         self::$METANAMESPACE = env('ODataMetaNamespace', 'Data');
         // If we aren't migrated, there's no DB tables to pull metadata _from_, so bail out early
         try {
-            if (!Schema::hasTable('migrations')) {
+            if (!Schema::hasTable(config('database.migrations'))) {
                 return;
             }
         } catch (\Exception $e) {

--- a/src/Providers/MetadataRouteProvider.php
+++ b/src/Providers/MetadataRouteProvider.php
@@ -47,9 +47,15 @@ class MetadataRouteProvider extends ServiceProvider
     {
         $auth_middleware = 'auth.basic';
 
-        $manager = App::make(\Illuminate\Contracts\Auth\Factory::class);
-        if ($manager->guard('api')) {
-            $auth_middleware = 'auth:api';
+        try {
+            if (class_exists(\Illuminate\Contracts\Auth\Factory::class)) {
+                $manager = App::make(\Illuminate\Contracts\Auth\Factory::class);
+                if ($manager->guard('api')) {
+                    $auth_middleware = 'auth:api';
+                }
+            }
+        } catch (\Exception $e) {
+
         }
 
         return $auth_middleware;

--- a/src/Providers/MetadataRouteProvider.php
+++ b/src/Providers/MetadataRouteProvider.php
@@ -47,15 +47,11 @@ class MetadataRouteProvider extends ServiceProvider
     {
         $auth_middleware = 'auth.basic';
 
-        try {
-            if (class_exists(\Illuminate\Contracts\Auth\Factory::class)) {
-                $manager = App::make(\Illuminate\Contracts\Auth\Factory::class);
-                if ($manager->guard('api')) {
-                    $auth_middleware = 'auth:api';
-                }
+        if (class_exists(\Illuminate\Contracts\Auth\Factory::class)) {
+            $manager = App::make(\Illuminate\Contracts\Auth\Factory::class);
+            if ($manager->guard('api')) {
+                $auth_middleware = 'auth:api';
             }
-        } catch (\Exception $e) {
-
         }
 
         return $auth_middleware;

--- a/src/Providers/MetadataRouteProvider.php
+++ b/src/Providers/MetadataRouteProvider.php
@@ -21,12 +21,12 @@ class MetadataRouteProvider extends ServiceProvider
     {
         Route::any(
             'odata.svc/{section}',
-            [ 'uses' => 'AlgoWeb\PODataLaravel\Controllers\ODataController@index', 'middleware' => 'auth.basic']
+            [ 'uses' => 'AlgoWeb\PODataLaravel\Controllers\ODataController@index', 'middleware' => 'auth:api']
         )
             ->where(['section' => '.*']);
         Route::any(
             'odata.svc',
-            [ 'uses' => 'AlgoWeb\PODataLaravel\Controllers\ODataController@index', 'middleware' => 'auth.basic']
+            [ 'uses' => 'AlgoWeb\PODataLaravel\Controllers\ODataController@index', 'middleware' => 'auth:api']
         );
     }
 

--- a/src/Providers/MetadataRouteProvider.php
+++ b/src/Providers/MetadataRouteProvider.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Providers;
 
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
@@ -19,14 +20,16 @@ class MetadataRouteProvider extends ServiceProvider
 
     private static function setupRoute()
     {
+        $auth_middleware = self::getAuthMiddleware();
+
         Route::any(
             'odata.svc/{section}',
-            [ 'uses' => 'AlgoWeb\PODataLaravel\Controllers\ODataController@index', 'middleware' => 'auth:api']
+            ['uses' => 'AlgoWeb\PODataLaravel\Controllers\ODataController@index', 'middleware' => $auth_middleware]
         )
             ->where(['section' => '.*']);
         Route::any(
             'odata.svc',
-            [ 'uses' => 'AlgoWeb\PODataLaravel\Controllers\ODataController@index', 'middleware' => 'auth:api']
+            ['uses' => 'AlgoWeb\PODataLaravel\Controllers\ODataController@index', 'middleware' => $auth_middleware]
         );
     }
 
@@ -38,5 +41,17 @@ class MetadataRouteProvider extends ServiceProvider
     public function register()
     {
         //
+    }
+
+    private static function getAuthMiddleware()
+    {
+        $auth_middleware = 'auth.basic';
+
+        $manager = App::make(\Illuminate\Contracts\Auth\Factory::class);
+        if ($manager->guard('api')) {
+            $auth_middleware = 'auth:api';
+        }
+
+        return $auth_middleware;
     }
 }

--- a/tests/unit/Providers/MetadataProviderTest.php
+++ b/tests/unit/Providers/MetadataProviderTest.php
@@ -68,7 +68,7 @@ class MetadataProviderTest extends TestCase
     public function testBootNoMigrations()
     {
         $schema = Schema::getFacadeRoot();
-        $schema->shouldReceive('hasTable')->withArgs(['migrations'])->andReturn(false)->once();
+        $schema->shouldReceive('hasTable')->withArgs([config('database.migrations')])->andReturn(false)->once();
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->boot();
@@ -419,7 +419,7 @@ class MetadataProviderTest extends TestCase
     private function setUpSchemaFacade()
     {
         $schema = Schema::getFacadeRoot();
-        $schema->shouldReceive('hasTable')->withArgs(['migrations'])->andReturn(true);
+        $schema->shouldReceive('hasTable')->withArgs([config('database.migrations')])->andReturn(true);
         $schema->shouldReceive('hasTable')->andReturn(true);
         $schema->shouldReceive('getColumnListing')->andReturn([]);
     }

--- a/tests/unit/Serialisers/SerialiserTestBase.php
+++ b/tests/unit/Serialisers/SerialiserTestBase.php
@@ -14,7 +14,7 @@ class SerialiserTestBase extends TestCase
     protected function setUpSchemaFacade()
     {
         $schema = Schema::getFacadeRoot();
-        $schema->shouldReceive('hasTable')->withArgs(['migrations'])->andReturn(true);
+        $schema->shouldReceive('hasTable')->withArgs([config('database.migrations')])->andReturn(true);
         $schema->shouldReceive('hasTable')->andReturn(true);
         $schema->shouldReceive('getColumnListing')->andReturn([]);
 


### PR DESCRIPTION
This pull request have the following points:

- 	Added supporting custom migration table name (getting from Laravel configurations instead fixing it as `migrations`
- 	Change the middleware from `auth:basic` to `auth:api` to support Passport authenticated requests
- 	Small change in composer.json adding `prefer-stable` parameter to not install all dependencies using `dev-master`, only when it is explicit 