### PR TITLE
Fix key setup

### DIFF
--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -340,33 +340,36 @@ trait MetadataTrait
                                 //Resolve the relation's model to a Relation object.
                                 $relationObj = $model->$method();
                                 if ($relationObj instanceof Relation) {
-                                    $relatedModel = '\\' . get_class($relationObj->getRelated());
-                                    $relations = [
-                                        'hasManyThrough',
-                                        'belongsToMany',
-                                        'hasMany',
-                                        'morphMany',
-                                        'morphToMany',
-                                        'morphedByMany'
-                                    ];
-                                    if (in_array($relation, $relations)) {
-                                        //Collection or array of models (because Collection is Arrayable)
-                                        $relationships['HasMany'][$method] = $biDir ? $relationObj : $relatedModel;
-                                    } elseif ('morphTo' === $relation) {
-                                        // Model isn't specified because relation is polymorphic
-                                        $relationships['UnknownPolyMorphSide'][$method] =
-                                            $biDir ? $relationObj : '\Illuminate\Database\Eloquent\Model|\Eloquent';
-                                    } else {
-                                        //Single model is returned
-                                        $relationships['HasOne'][$method] = $biDir ? $relationObj : $relatedModel;
-                                    }
-                                    if (in_array($relation, ['morphMany', 'morphOne', 'morphToMany'])) {
-                                        $relationships['KnownPolyMorphSide'][$method] =
-                                            $biDir ? $relationObj : $relatedModel;
-                                    }
-                                    if (in_array($relation, ['morphedByMany'])) {
-                                        $relationships['UnknownPolyMorphSide'][$method] =
-                                            $biDir ? $relationObj : $relatedModel;
+                                    $relObject = $relationObj->getRelated();
+                                    $relatedModel = '\\' . get_class($relObject);
+                                    if (in_array(MetadataTrait::class, class_uses($relatedModel))) {
+                                        $relations = [
+                                            'hasManyThrough',
+                                            'belongsToMany',
+                                            'hasMany',
+                                            'morphMany',
+                                            'morphToMany',
+                                            'morphedByMany'
+                                        ];
+                                        if (in_array($relation, $relations)) {
+                                            //Collection or array of models (because Collection is Arrayable)
+                                            $relationships['HasMany'][$method] = $biDir ? $relationObj : $relatedModel;
+                                        } elseif ('morphTo' === $relation) {
+                                            // Model isn't specified because relation is polymorphic
+                                            $relationships['UnknownPolyMorphSide'][$method] =
+                                                $biDir ? $relationObj : '\Illuminate\Database\Eloquent\Model|\Eloquent';
+                                        } else {
+                                            //Single model is returned
+                                            $relationships['HasOne'][$method] = $biDir ? $relationObj : $relatedModel;
+                                        }
+                                        if (in_array($relation, ['morphMany', 'morphOne', 'morphToMany'])) {
+                                            $relationships['KnownPolyMorphSide'][$method] =
+                                                $biDir ? $relationObj : $relatedModel;
+                                        }
+                                        if (in_array($relation, ['morphedByMany'])) {
+                                            $relationships['UnknownPolyMorphSide'][$method] =
+                                                $biDir ? $relationObj : $relatedModel;
+                                        }
                                     }
                                 }
                             }

--- a/tests/TestMorphManySourceWithUnexposedTarget.php
+++ b/tests/TestMorphManySourceWithUnexposedTarget.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace AlgoWeb\PODataLaravel\Providers;
+
+use AlgoWeb\PODataLaravel\Models\MetadataTrait;
+use AlgoWeb\PODataLaravel\Models\TestMorphUnexposedTarget;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Mockery as m;
+
+class TestMorphManySourceWithUnexposedTarget extends Model
+{
+    use MetadataTrait {
+        metadata as traitmetadata; // Need to alias the trait version of the method so we can call it and
+        // not bury ourselves under a stack overflow and segfault
+        getRelationshipsFromMethods as getRel;
+    }
+
+    protected $metaArray;
+    protected $connect;
+    protected $grammar;
+    protected $processor;
+
+    protected $morphRelation;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['*'];
+
+    public $primaryKey = 'alternate_id';
+
+    public function __construct(array $meta = null, Connection $connect = null)
+    {
+        if (isset($meta)) {
+            $this->metaArray = $meta;
+        }
+        if (isset($connect)) {
+            $this->connect = $connect;
+        } else {
+            $this->processor = \Mockery::mock(\Illuminate\Database\Query\Processors\Processor::class)->makePartial();
+            $this->grammar = \Mockery::mock(\Illuminate\Database\Query\Grammars\Grammar::class)->makePartial();
+            $connect = \Mockery::mock(Connection::class)->makePartial();
+            $connect->shouldReceive('getQueryGrammar')->andReturn($this->grammar);
+            $connect->shouldReceive('getPostProcessor')->andReturn($this->processor);
+            $this->connect = $connect;
+            assert(null !== $this->connect);
+            assert(null !== $this->connect->getQueryGrammar());
+            assert(null !== $this->connect->getPostProcessor());
+        }
+        parent::__construct();
+        $morph = m::mock(MorphMany::class)->makePartial();
+        $related = m::mock(TestMorphUnexposedTarget::class)->makePartial();
+        $morph->shouldReceive('getRelated')->andReturn($related);
+        $this->morphRelation = $morph;
+    }
+
+    public function getTable()
+    {
+        return 'testmorphmanysourcewithunexposedtarget';
+    }
+
+    public function getConnectionName()
+    {
+        return 'testconnection';
+    }
+
+    public function getConnection()
+    {
+        return $this->connect;
+    }
+
+    public function metadata()
+    {
+        if (isset($this->metaArray)) {
+            return $this->metaArray;
+        }
+        return $this->traitmetadata();
+    }
+
+    public function getRelationshipsFromMethods($biDir = false)
+    {
+        return $this->getRel($biDir);
+    }
+
+    public function morphTarget()
+    {
+        return $this->morphRelation;
+    }
+}

--- a/tests/TestMorphUnexposedTarget.php
+++ b/tests/TestMorphUnexposedTarget.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AlgoWeb\PODataLaravel\Models;
+
+use Illuminate\Database\Connection;
+use Illuminate\Database\Eloquent\Model;
+use Mockery as m;
+
+class TestMorphUnexposedTarget extends Model
+{
+    protected $connect;
+
+    /**
+     * TestMorphUnexposedTarget constructor.
+     * @param array|null $meta
+     * @param Connection|null $connect
+     */
+    public function __construct(Connection $connect = null)
+    {
+        if (isset($connect)) {
+            $this->connect = $connect;
+        } else {
+            $connect = m::mock(Connection::class)->makePartial();
+            $this->connect = $connect;
+        }
+        parent::__construct();
+    }
+
+    public function getTable()
+    {
+        return 'testmorphunexposedtarget';
+    }
+
+    public function getConnectionName()
+    {
+        return 'testconnection';
+    }
+
+    public function getConnection()
+    {
+        return $this->connect;
+    }
+
+    public function morph()
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/unit/Models/MetadataTraitTest.php
+++ b/tests/unit/Models/MetadataTraitTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Models;
 
+use AlgoWeb\PODataLaravel\Providers\TestMorphManySourceWithUnexposedTarget;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\App;
@@ -679,6 +680,8 @@ class MetadataTraitTest extends TestCase
             [TestMorphOneSource::class, false],
             [TestMorphOneSourceAlternate::class, false],
             [TestMorphTarget::class, true],
+            [TestMorphTarget::class, true],
+            [TestMorphManySourceWithUnexposedTarget::class, false]
         ];
     }
 
@@ -711,6 +714,7 @@ class MetadataTraitTest extends TestCase
             [TestMorphOneSource::class, true],
             [TestMorphOneSourceAlternate::class, true],
             [TestMorphTarget::class, false],
+            [TestMorphManySourceWithUnexposedTarget::class, false]
         ];
     }
 }

--- a/tests/unit/Providers/MetadataProviderTest.php
+++ b/tests/unit/Providers/MetadataProviderTest.php
@@ -124,7 +124,7 @@ class MetadataProviderTest extends TestCase
             TestMonomorphicSource::class, TestMonomorphicTarget::class, TestMorphManyToManySource::class,
             TestMorphManyToManyTarget::class, TestMonomorphicOneAndManySource::class,
             TestMonomorphicOneAndManyTarget::class, TestCastModel::class, TestMorphOneSourceAlternate::class,
-            TestMorphManySourceAlternate::class];
+            TestMorphManySourceAlternate::class, TestMorphManySourceWithUnexposedTarget::class];
 
         foreach ($classen as $className) {
             $testModel = m::mock($className)->makePartial();


### PR DESCRIPTION
Only bother bolting relations in that have both ends exposed.

Original bug case was an exposed unknown-side model having a polymorphic 1:1 relation with an unexposed known-side model, which falsely flagged exposed model as polymorphic-affected (has a base type, etc etc, unlimited rice pudding for all).

Simplest and most performant way to handle that was, as relations are being processed, to only proceed if related model is also exposed.