### PR TITLE
Fix relation calculation

### DIFF
--- a/src/Models/MetadataRelationHolder.php
+++ b/src/Models/MetadataRelationHolder.php
@@ -218,4 +218,12 @@ class MetadataRelationHolder
             throw new \InvalidArgumentException($msg);
         }
     }
+
+    /**
+     * Reset stored relations
+     */
+    public function reset()
+    {
+        $this->relations = [];
+    }
 }

--- a/src/Models/MetadataRelationHolder.php
+++ b/src/Models/MetadataRelationHolder.php
@@ -75,28 +75,15 @@ class MetadataRelationHolder
                     if (!array_key_exists($foreignType, $this->relations)) {
                         continue;
                     }
-                    foreach ($raw as $dependentProperty => $dependentPayload) {
-                        if ($keyName == $dependentPayload['local']) {
-                            $dependentMult = $dependentPayload['multiplicity'];
-                            // generate forward and reverse relations
-                            list($forward, $reverse) = $this->calculateRoundTripRelationsGenForwardReverse(
-                                $principalType,
-                                $principalMult,
-                                $principalProperty,
-                                $dependentType,
-                                $dependentMult,
-                                $dependentProperty
-                            );
-                            if (!in_array($forward, $result)) {
-                                // add forward relation
-                                $result[] = $forward;
-                            }
-                            if (!in_array($reverse, $result)) {
-                                // add reverse relation
-                                $result[] = $reverse;
-                            }
-                        }
-                    }
+                    $result = $this->generateRoundTripRelations(
+                        $principalType,
+                        $keyName,
+                        $raw,
+                        $principalMult,
+                        $principalProperty,
+                        $dependentType,
+                        $result
+                    );
                 }
             }
         }
@@ -136,28 +123,16 @@ class MetadataRelationHolder
                     if ($targType != $principalType) {
                         continue;
                     }
-                    foreach ($interDeets as $dependentProperty => $finalDeets) {
-                        if ($keyName !== $finalDeets['local']) {
-                            continue;
-                        }
-                        $dependentMult = $finalDeets['multiplicity'];
-                        list($forward, $reverse) = $this->calculateRoundTripRelationsGenForwardReverse(
-                            $principalType,
-                            $principalMult,
-                            $principalProperty,
-                            $dependentType,
-                            $dependentMult,
-                            $dependentProperty
-                        );
-                        if (!in_array($forward, $result)) {
-                            // add forward relation
-                            $result[] = $forward;
-                        }
-                        if (!in_array($reverse, $result)) {
-                            // add reverse relation
-                            $result[] = $reverse;
-                        }
-                    }
+                    $raw = $interDeets;
+                    $result = $this->generateRoundTripRelations(
+                        $principalType,
+                        $keyName,
+                        $raw,
+                        $principalMult,
+                        $principalProperty,
+                        $dependentType,
+                        $result
+                    );
                 }
             }
         }
@@ -225,5 +200,49 @@ class MetadataRelationHolder
     public function reset()
     {
         $this->relations = [];
+    }
+
+    /**
+     * @param $principalType
+     * @param $keyName
+     * @param $raw
+     * @param $principalMult
+     * @param $principalProperty
+     * @param $dependentType
+     * @param $result
+     * @return array
+     */
+    private function generateRoundTripRelations(
+        $principalType,
+        $keyName,
+        $raw,
+        $principalMult,
+        $principalProperty,
+        $dependentType,
+        $result
+    ) {
+        foreach ($raw as $dependentProperty => $dependentPayload) {
+            if ($keyName !== $dependentPayload['local']) {
+                continue;
+            }
+            $dependentMult = $dependentPayload['multiplicity'];
+            list($forward, $reverse) = $this->calculateRoundTripRelationsGenForwardReverse(
+                $principalType,
+                $principalMult,
+                $principalProperty,
+                $dependentType,
+                $dependentMult,
+                $dependentProperty
+            );
+            if (!in_array($forward, $result)) {
+                // add forward relation
+                $result[] = $forward;
+            }
+            if (!in_array($reverse, $result)) {
+                // add reverse relation
+                $result[] = $reverse;
+            }
+        }
+        return $result;
     }
 }

--- a/src/Models/MetadataRelationHolder.php
+++ b/src/Models/MetadataRelationHolder.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace AlgoWeb\PODataLaravel\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MetadataRelationHolder
+{
+    protected $multConstraints = [ '0..1' => ['1'], '1' => ['0..1', '*'], '*' => ['1', '*']];
+    protected $relations = [];
+
+    public function __construct()
+    {
+    }
+
+    /**
+     * Add model's relationships to holder
+     *
+     * @param Model $model
+     */
+    public function addModel(Model $model)
+    {
+        if (!in_array('AlgoWeb\\PODataLaravel\\Models\\MetadataTrait', class_uses($model))) {
+            $msg = 'Supplied model does not use MetadataTrait';
+            throw new \InvalidArgumentException($msg);
+        }
+        $className = get_class($model);
+        if (array_key_exists($className, $this->relations)) {
+            $msg = $className.' already added';
+            throw new \InvalidArgumentException($msg);
+        }
+        $this->relations[$className] = $model->getRelationships();
+    }
+
+    public function getRelationsByKey($className, $keyName)
+    {
+        if (!array_key_exists($className, $this->relations)) {
+            $msg = $className . ' does not exist in holder';
+            throw new \InvalidArgumentException($msg);
+        }
+
+        $rels = $this->relations[$className];
+        if (!array_key_exists($keyName, $rels)) {
+            $msg = 'Key ' . $keyName . ' not registered on ' . $className;
+            throw new \InvalidArgumentException($msg);
+        }
+
+        $result = [];
+        $payload = $rels[$keyName];
+        $principalType = $className;
+        foreach ($payload as $dependentType => $targDeets) {
+            if (!array_key_exists($dependentType, $this->relations)) {
+                continue;
+            }
+            // if principal and ostensible dependent type are equal, drop through to specific handler
+            // at moment, this is only for morphTo relations - morphedByMany doesn't cause this
+            if ($principalType === $dependentType) {
+                $morphToLines = $this->getMorphToRelations($principalType, $targDeets, $keyName);
+                foreach ($morphToLines as $morph) {
+                    if (!in_array($morph, $result)) {
+                        $result[] = $morph;
+                    }
+                }
+                continue;
+            }
+
+            $foreign = $this->relations[$dependentType];
+
+            foreach ($targDeets as $principalProperty => $rawDeets) {
+                $targKey = $rawDeets['local'];
+                $principalMult = $rawDeets['multiplicity'];
+                $principalProperty = $rawDeets['property'];
+                if (!array_key_exists($targKey, $foreign)) {
+                    continue;
+                }
+                $foreignDeets = $foreign[$targKey];
+                foreach ($foreignDeets as $foreignType => $raw) {
+                    if (!array_key_exists($foreignType, $this->relations)) {
+                        continue;
+                    }
+                    foreach ($raw as $dependentProperty => $dependentPayload) {
+                        if ($keyName == $dependentPayload['local']) {
+                            $dependentMult = $dependentPayload['multiplicity'];
+                            // generate forward and reverse relations
+                            list($forward, $reverse) = $this->calculateRoundTripRelationsGenForwardReverse(
+                                $principalType,
+                                $principalMult,
+                                $principalProperty,
+                                $dependentType,
+                                $dependentMult,
+                                $dependentProperty
+                            );
+                            if (!in_array($forward, $result)) {
+                                // add forward relation
+                                $result[] = $forward;
+                            }
+                            if (!in_array($reverse, $result)) {
+                                // add reverse relation
+                                $result[] = $reverse;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return $result;
+    }
+
+    public function getRelationsByClass($className)
+    {
+        if (!array_key_exists($className, $this->relations)) {
+            $msg = $className . ' does not exist in holder';
+            throw new \InvalidArgumentException($msg);
+        }
+
+        $rels = $this->relations[$className];
+        $keys = array_keys($rels);
+        $results = [];
+        foreach ($keys as $key) {
+            $lines = $this->getRelationsByKey($className, $key);
+            foreach ($lines as $line) {
+                if (!in_array($line, $results)) {
+                    $results[] = $line;
+                }
+            }
+        }
+
+        return $results;
+    }
+
+    private function getMorphToRelations($principalType, $targDeets, $keyName)
+    {
+        $result = [];
+        $deetKeys = array_keys($targDeets);
+        $principalProperty = $deetKeys[0];
+        $principalDeets = $targDeets[$principalProperty];
+        $principalMult = $principalDeets['multiplicity'];
+
+        foreach ($this->relations as $dependentType => $dependentDeets) {
+            foreach ($dependentDeets as $targKey => $rawDeets) {
+                foreach ($rawDeets as $targType => $interDeets) {
+                    if ($targType != $principalType) {
+                        continue;
+                    }
+                    foreach ($interDeets as $dependentProperty => $finalDeets) {
+                        if ($keyName !== $finalDeets['local']) {
+                            continue;
+                        }
+                        $dependentMult = $finalDeets['multiplicity'];
+                        list($forward, $reverse) = $this->calculateRoundTripRelationsGenForwardReverse(
+                            $principalType,
+                            $principalMult,
+                            $principalProperty,
+                            $dependentType,
+                            $dependentMult,
+                            $dependentProperty
+                        );
+                        if (!in_array($forward, $result)) {
+                            // add forward relation
+                            $result[] = $forward;
+                        }
+                        if (!in_array($reverse, $result)) {
+                            // add reverse relation
+                            $result[] = $reverse;
+                        }
+                    }
+                }
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @param $principalType
+     * @param $principalMult
+     * @param $principalProperty
+     * @param $dependentType
+     * @param $dependentMult
+     * @param $dependentProperty
+     * @return array[]
+     */
+    private function calculateRoundTripRelationsGenForwardReverse(
+        $principalType,
+        $principalMult,
+        $principalProperty,
+        $dependentType,
+        $dependentMult,
+        $dependentProperty
+    ) {
+        assert(
+            in_array($dependentMult, $this->multConstraints[$principalMult]),
+            'Cannot pair multiplicities ' . $dependentMult . ' and ' . $principalMult
+        );
+        assert(
+            in_array($principalMult, $this->multConstraints[$dependentMult]),
+            'Cannot pair multiplicities ' . $principalMult . ' and ' . $dependentMult
+        );
+        $forward = [
+            'principalType' => $principalType,
+            'principalMult' => $dependentMult,
+            'principalProp' => $principalProperty,
+            'dependentType' => $dependentType,
+            'dependentMult' => $principalMult,
+            'dependentProp' => $dependentProperty
+        ];
+        $reverse = [
+            'principalType' => $dependentType,
+            'principalMult' => $principalMult,
+            'principalProp' => $dependentProperty,
+            'dependentType' => $principalType,
+            'dependentMult' => $dependentMult,
+            'dependentProp' => $principalProperty
+        ];
+        return [$forward, $reverse];
+    }
+}

--- a/src/Models/MetadataRelationHolder.php
+++ b/src/Models/MetadataRelationHolder.php
@@ -34,10 +34,7 @@ class MetadataRelationHolder
 
     public function getRelationsByKey($className, $keyName)
     {
-        if (!array_key_exists($className, $this->relations)) {
-            $msg = $className . ' does not exist in holder';
-            throw new \InvalidArgumentException($msg);
-        }
+        $this->checkClassExists($className);
 
         $rels = $this->relations[$className];
         if (!array_key_exists($keyName, $rels)) {
@@ -108,10 +105,7 @@ class MetadataRelationHolder
 
     public function getRelationsByClass($className)
     {
-        if (!array_key_exists($className, $this->relations)) {
-            $msg = $className . ' does not exist in holder';
-            throw new \InvalidArgumentException($msg);
-        }
+        $this->checkClassExists($className);
 
         $rels = $this->relations[$className];
         $keys = array_keys($rels);
@@ -212,5 +206,16 @@ class MetadataRelationHolder
             'dependentProp' => $principalProperty
         ];
         return [$forward, $reverse];
+    }
+
+    /**
+     * @param $className
+     */
+    protected function checkClassExists($className)
+    {
+        if (!array_key_exists($className, $this->relations)) {
+            $msg = $className . ' does not exist in holder';
+            throw new \InvalidArgumentException($msg);
+        }
     }
 }

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -541,8 +541,9 @@ trait MetadataTrait
      * @param $last
      * @param $mult
      * @param $targ
+     * @param string|null $targ
      */
-    private function addRelationsHook(&$hooks, $first, $property, $last, $mult, $targ)
+    private function addRelationsHook(&$hooks, $first, $property, $last, $mult, $targ, $type = null)
     {
         if (!isset($hooks[$first])) {
             $hooks[$first] = [];
@@ -550,7 +551,8 @@ trait MetadataTrait
         $hooks[$first][$targ] = [
             'property' => $property,
             'local' => $last,
-            'multiplicity' => $mult
+            'multiplicity' => $mult,
+            'type' => $type
         ];
     }
 
@@ -635,7 +637,7 @@ trait MetadataTrait
             $localName = $localSegments[count($localSegments) - 1];
             $first = $isMany ? $keyName : $localName;
             $last = $isMany ? $localName : $keyName;
-            $this->addRelationsHook($hooks, $first, $property, $last, $mult, $targ);
+            $this->addRelationsHook($hooks, $first, $property, $last, $mult, $targ, 'unknown');
         }
     }
 
@@ -662,7 +664,7 @@ trait MetadataTrait
 
             $first = $keyName;
             $last = (isset($localName) && '' != $localName) ? $localName : $foo->getRelated()->getKeyName();
-            $this->addRelationsHook($hooks, $first, $property, $last, $mult, $targ);
+            $this->addRelationsHook($hooks, $first, $property, $last, $mult, $targ, 'known');
         }
     }
 

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -548,7 +548,10 @@ trait MetadataTrait
         if (!isset($hooks[$first])) {
             $hooks[$first] = [];
         }
-        $hooks[$first][$targ] = [
+        if (!isset($hooks[$first][$targ])) {
+            $hooks[$first][$targ] = [];
+        }
+        $hooks[$first][$targ][$property] = [
             'property' => $property,
             'local' => $last,
             'multiplicity' => $mult,

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -226,12 +226,13 @@ class MetadataProvider extends MetadataBaseProvider
             $hook = $hooks[$key];
             foreach ($hook as $barb) {
                 foreach ($barb as $knownType => $propData) {
+                    $propName = array_keys($propData)[0];
                     if (in_array($knownType, $knownKeys)) {
                         if (!isset($knownSide[$knownType][$key])) {
                             $knownSide[$knownType][$key] = [];
                         }
                         assert(isset($knownSide[$knownType][$key]));
-                        $knownSide[$knownType][$key][] = $propData['property'];
+                        $knownSide[$knownType][$key][] = $propData[$propName]['property'];
                     }
                 }
             }
@@ -303,9 +304,10 @@ class MetadataProvider extends MetadataBaseProvider
         foreach ($remix as $principalType => $value) {
             foreach ($value as $fk => $localRels) {
                 foreach ($localRels as $dependentType => $deets) {
-                    $principalMult = $deets['multiplicity'];
-                    $principalProperty = $deets['property'];
-                    $principalKey = $deets['local'];
+                    $propName = array_keys($deets)[0];
+                    $principalMult = $deets[$propName]['multiplicity'];
+                    $principalProperty = $deets[$propName]['property'];
+                    $principalKey = $deets[$propName]['local'];
 
                     if (!isset($remix[$dependentType])) {
                         continue;
@@ -315,8 +317,9 @@ class MetadataProvider extends MetadataBaseProvider
                         continue;
                     }
                     $foreign = $foreign[$principalKey];
-                    $dependentMult = $foreign[$dependentType]['multiplicity'];
-                    $dependentProperty = $foreign[$dependentType]['property'];
+                    $propName = array_keys($foreign[$dependentType])[0];
+                    $dependentMult = $foreign[$dependentType][$propName]['multiplicity'];
+                    $dependentProperty = $foreign[$dependentType][$propName]['property'];
                     assert(
                         in_array($dependentMult, $this->multConstraints[$principalMult]),
                         'Cannot pair multiplicities ' . $dependentMult . ' and ' . $principalMult
@@ -357,17 +360,19 @@ class MetadataProvider extends MetadataBaseProvider
                     if (!isset($hooks[$dependentType])) {
                         continue;
                     }
-                    $principalMult = $deets['multiplicity'];
-                    $principalProperty = $deets['property'];
-                    $principalKey = $deets['local'];
+                    $propName = array_keys($deets)[0];
+                    $principalMult = $deets[$propName]['multiplicity'];
+                    $principalProperty = $deets[$propName]['property'];
+                    $principalKey = $deets[$propName]['local'];
 
                     $foreign = $hooks[$dependentType];
                     $foreign = null != $foreign && isset($foreign[$principalKey]) ? $foreign[$principalKey] : null;
 
                     if (null != $foreign && isset($foreign[$principalType])) {
                         $foreign = $foreign[$principalType];
-                        $dependentMult = $foreign['multiplicity'];
-                        $dependentProperty = $foreign['property'];
+                        $propName = array_keys($foreign)[0];
+                        $dependentMult = $foreign[$propName]['multiplicity'];
+                        $dependentProperty = $foreign[$propName]['property'];
                         assert(
                             in_array($dependentMult, $this->multConstraints[$principalMult]),
                             'Cannot pair multiplicities ' . $dependentMult . ' and ' . $principalMult

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -31,7 +31,6 @@ class MetadataProvider extends MetadataBaseProvider
      * Create a new service provider instance.
      *
      * @param  \Illuminate\Contracts\Foundation\Application  $app
-     * @return void
      */
     public function __construct($app)
     {
@@ -155,6 +154,11 @@ class MetadataProvider extends MetadataBaseProvider
         return [$entityTypes, $resourceSets, $begins];
     }
 
+    /**
+     * Get round-trip relations before inserting polymorphic-powered placeholders
+     *
+     * @return array[]
+     */
     public function calculateRoundTripRelations()
     {
         if (!isset(static::$rawRelationCache)) {

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Providers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
@@ -21,8 +22,22 @@ class MetadataProvider extends MetadataBaseProvider
     protected $multConstraints = [ '0..1' => ['1'], '1' => ['0..1', '*'], '*' => ['1', '*']];
     protected static $metaNAMESPACE = 'Data';
     protected static $relationCache;
+    protected static $rawRelationCache;
     const POLYMORPHIC = 'polyMorphicPlaceholder';
     const POLYMORPHIC_PLURAL = 'polyMorphicPlaceholders';
+    protected $relationHolder;
+
+    /**
+     * Create a new service provider instance.
+     *
+     * @param  \Illuminate\Contracts\Foundation\Application  $app
+     * @return void
+     */
+    public function __construct($app)
+    {
+        parent::__construct($app);
+        $this->relationHolder = new MetadataRelationHolder();
+    }
 
     /**
      * Bootstrap the application services.  Post-boot.
@@ -142,42 +157,31 @@ class MetadataProvider extends MetadataBaseProvider
 
     public function calculateRoundTripRelations()
     {
-        $modelNames = $this->getCandidateModels();
+        if (!isset(static::$rawRelationCache)) {
+            $modelNames = $this->getCandidateModels();
 
-        $hooks = [];
-        foreach ($modelNames as $name) {
-            $model = new $name();
-            $rels = $model->getRelationships();
-            // it doesn't matter if a model has no relationships here, that lack will simply be skipped over
-            // during hookup processing
-            $hooks[$name] = $rels;
-        }
-
-        // model relation gubbins are assembled, now the hard bit starts
-        // storing assembled bidirectional relationship schema
-        $rawLines = [];
-        // storing unprocessed relation gubbins for second-pass processing
-        $remix = [];
-        $this->calculateRoundTripRelationsFirstPass($hooks, $rawLines, $remix);
-
-        // now for second processing pass, to pick up stuff that first didn't handle
-        $rawLines = $this->calculateRoundTripRelationsSecondPass($remix, $rawLines);
-
-        $numLines = count($rawLines);
-        for ($i = 0; $i < $numLines; $i++) {
-            $rawLines[$i]['principalRSet'] = $rawLines[$i]['principalType'];
-            $rawLines[$i]['dependentRSet'] = $rawLines[$i]['dependentType'];
-        }
-
-        // deduplicate rawLines - can't use array_unique as array value elements are themselves arrays
-        $lines = [];
-        foreach ($rawLines as $line) {
-            if (!in_array($line, $lines)) {
-                $lines[] = $line;
+            foreach ($modelNames as $name) {
+                $model = new $name();
+                $this->getRelationHolder()->addModel($model);
             }
+
+            // model relation gubbins are assembled, now fish out relation results from holder
+            $lines = [];
+            foreach ($modelNames as $name) {
+                $workLines = $this->getRelationHolder()->getRelationsByClass($name);
+                foreach ($workLines as $work) {
+                    // if this relation line is already in $rawLines, don't add it again
+                    $work['principalRSet'] = $work['principalType'];
+                    $work['dependentRSet'] = $work['dependentType'];
+                    if (!in_array($work, $lines)) {
+                        $lines[] = $work;
+                    }
+                }
+            }
+            static::$rawRelationCache = $lines;
         }
 
-        return $lines;
+        return static::$rawRelationCache;
     }
 
     public function getPolymorphicRelationGroups()
@@ -292,159 +296,6 @@ class MetadataProvider extends MetadataBaseProvider
             self::$relationCache = $rels;
         }
         return self::$relationCache;
-    }
-
-    /**
-     * @param $remix
-     * @param $lines
-     * @return array
-     */
-    private function calculateRoundTripRelationsSecondPass($remix, $lines)
-    {
-        foreach ($remix as $principalType => $value) {
-            foreach ($value as $fk => $localRels) {
-                foreach ($localRels as $dependentType => $deets) {
-                    $propName = array_keys($deets)[0];
-                    $principalMult = $deets[$propName]['multiplicity'];
-                    $principalProperty = $deets[$propName]['property'];
-                    $principalKey = $deets[$propName]['local'];
-
-                    if (!isset($remix[$dependentType])) {
-                        continue;
-                    }
-                    $foreign = $remix[$dependentType];
-                    if (!isset($foreign[$principalKey])) {
-                        continue;
-                    }
-                    $foreign = $foreign[$principalKey];
-                    $propName = array_keys($foreign[$dependentType])[0];
-                    $dependentMult = $foreign[$dependentType][$propName]['multiplicity'];
-                    $dependentProperty = $foreign[$dependentType][$propName]['property'];
-                    assert(
-                        in_array($dependentMult, $this->multConstraints[$principalMult]),
-                        'Cannot pair multiplicities ' . $dependentMult . ' and ' . $principalMult
-                    );
-                    assert(
-                        in_array($principalMult, $this->multConstraints[$dependentMult]),
-                        'Cannot pair multiplicities ' . $principalMult . ' and ' . $dependentMult
-                    );
-                    // generate forward and reverse relations
-                    list($forward, $reverse) = $this->calculateRoundTripRelationsGenForwardReverse(
-                        $principalType,
-                        $principalMult,
-                        $principalProperty,
-                        $dependentType,
-                        $dependentMult,
-                        $dependentProperty
-                    );
-                    // add forward relation
-                    $lines[] = $forward;
-                    // add reverse relation
-                    $lines[] = $reverse;
-                }
-            }
-        }
-        return $lines;
-    }
-
-    /**
-     * @param $hooks
-     * @param $lines
-     * @param $remix
-     */
-    private function calculateRoundTripRelationsFirstPass($hooks, &$lines, &$remix)
-    {
-        foreach ($hooks as $principalType => $value) {
-            foreach ($value as $fk => $localRels) {
-                foreach ($localRels as $dependentType => $deets) {
-                    if (!isset($hooks[$dependentType])) {
-                        continue;
-                    }
-                    $propName = array_keys($deets)[0];
-                    $principalMult = $deets[$propName]['multiplicity'];
-                    $principalProperty = $deets[$propName]['property'];
-                    $principalKey = $deets[$propName]['local'];
-
-                    $foreign = $hooks[$dependentType];
-                    $foreign = null != $foreign && isset($foreign[$principalKey]) ? $foreign[$principalKey] : null;
-
-                    if (null != $foreign && isset($foreign[$principalType])) {
-                        $foreign = $foreign[$principalType];
-                        $propName = array_keys($foreign)[0];
-                        $dependentMult = $foreign[$propName]['multiplicity'];
-                        $dependentProperty = $foreign[$propName]['property'];
-                        assert(
-                            in_array($dependentMult, $this->multConstraints[$principalMult]),
-                            'Cannot pair multiplicities ' . $dependentMult . ' and ' . $principalMult
-                        );
-                        assert(
-                            in_array($principalMult, $this->multConstraints[$dependentMult]),
-                            'Cannot pair multiplicities ' . $principalMult . ' and ' . $dependentMult
-                        );
-                        // generate forward and reverse relations
-                        list($forward, $reverse) = $this->calculateRoundTripRelationsGenForwardReverse(
-                            $principalType,
-                            $principalMult,
-                            $principalProperty,
-                            $dependentType,
-                            $dependentMult,
-                            $dependentProperty
-                        );
-                        // add forward relation
-                        $lines[] = $forward;
-                        // add reverse relation
-                        $lines[] = $reverse;
-                    } else {
-                        if (!isset($remix[$principalType])) {
-                            $remix[$principalType] = [];
-                        }
-                        if (!isset($remix[$principalType][$fk])) {
-                            $remix[$principalType][$fk] = [];
-                        }
-                        if (!isset($remix[$principalType][$fk][$dependentType])) {
-                            $remix[$principalType][$fk][$dependentType] = $deets;
-                        }
-                        assert(isset($remix[$principalType][$fk][$dependentType]));
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * @param $principalType
-     * @param $principalMult
-     * @param $principalProperty
-     * @param $dependentType
-     * @param $dependentMult
-     * @param $dependentProperty
-     * @return array[]
-     */
-    private function calculateRoundTripRelationsGenForwardReverse(
-        $principalType,
-        $principalMult,
-        $principalProperty,
-        $dependentType,
-        $dependentMult,
-        $dependentProperty
-    ) {
-        $forward = [
-            'principalType' => $principalType,
-            'principalMult' => $dependentMult,
-            'principalProp' => $principalProperty,
-            'dependentType' => $dependentType,
-            'dependentMult' => $principalMult,
-            'dependentProp' => $dependentProperty
-        ];
-        $reverse = [
-            'principalType' => $dependentType,
-            'principalMult' => $principalMult,
-            'principalProp' => $dependentProperty,
-            'dependentType' => $principalType,
-            'dependentMult' => $dependentMult,
-            'dependentProp' => $principalProperty
-        ];
-        return [$forward, $reverse];
     }
 
     private function processRelationLine($line, $entityTypes, &$meta)
@@ -605,6 +456,8 @@ class MetadataProvider extends MetadataBaseProvider
     public function reset()
     {
         self::$relationCache = null;
+        self::$rawRelationCache = null;
+        $this->getRelationHolder()->reset();
     }
 
     /**
@@ -636,5 +489,14 @@ class MetadataProvider extends MetadataBaseProvider
         $result = 0 === count($trim) ? null : $trim[0]['dependentProp'];
 
         return $result;
+    }
+
+    /**
+     * @return MetadataRelationHolder
+     */
+    public function getRelationHolder()
+    {
+        assert(null !== $this->relationHolder, 'Relation holder must not be null');
+        return $this->relationHolder;
     }
 }

--- a/tests/TestMonomorphicManySource.php
+++ b/tests/TestMonomorphicManySource.php
@@ -62,4 +62,9 @@ class TestMonomorphicManySource extends Model
         }
         return $this->traitmetadata();
     }
+
+    public function getRelationshipsFromMethods($biDir = false)
+    {
+        return $this->getRel($biDir);
+    }
 }

--- a/tests/TestMonomorphicOneAndManySource.php
+++ b/tests/TestMonomorphicOneAndManySource.php
@@ -63,7 +63,7 @@ class TestMonomorphicOneAndManySource extends Model
 
     public function twoTarget()
     {
-        return $this->hasOne(TestMonomorphicTarget::class, 'one_id');
+        return $this->hasOne(TestMonomorphicOneAndManyTarget::class, 'two_id');
     }
 
     public function manyTarget()

--- a/tests/TestMonomorphicOneAndManyTarget.php
+++ b/tests/TestMonomorphicOneAndManyTarget.php
@@ -58,16 +58,16 @@ class TestMonomorphicOneAndManyTarget extends Model
 
     public function oneSource()
     {
-        return $this->belongsTo(TestMonomorphicOneAndManyTarget::class, 'one_id');
+        return $this->belongsTo(TestMonomorphicOneAndManySource::class, 'one_id');
     }
 
     public function twoSource()
     {
-        return $this->belongsTo(TestMonomorphicOneAndManyTarget::class, 'two_id');
+        return $this->belongsTo(TestMonomorphicOneAndManySource::class, 'two_id');
     }
 
     public function manySource()
     {
-        return $this->belongsTo(TestMonomorphicOneAndManyTarget::class, 'many_id');
+        return $this->belongsTo(TestMonomorphicOneAndManySource::class, 'many_id');
     }
 }

--- a/tests/TestMorphTargetAlternate.php
+++ b/tests/TestMorphTargetAlternate.php
@@ -7,7 +7,7 @@ use Illuminate\Database\Eloquent\Model as Model;
 use Illuminate\Database\Connection as Connection;
 use Mockery\Mockery;
 
-class TestMonomorphicManyTarget extends Model
+class TestMorphTargetAlternate extends Model
 {
     use MetadataTrait {
         metadata as traitmetadata; // Need to alias the trait version of the method so we can call it and
@@ -37,6 +37,11 @@ class TestMonomorphicManyTarget extends Model
         parent::__construct();
     }
 
+    public function getTable()
+    {
+        return 'testmorphtargetalternate';
+    }
+
     public function getConnectionName()
     {
         return 'testconnection';
@@ -45,11 +50,6 @@ class TestMonomorphicManyTarget extends Model
     public function getConnection()
     {
         return $this->connect;
-    }
-
-    public function manyTarget()
-    {
-        return $this->belongsToMany(TestMonomorphicManySource::class, "target_source", "many_id", "many_source");
     }
 
     public function metadata()
@@ -63,5 +63,10 @@ class TestMonomorphicManyTarget extends Model
     public function getRelationshipsFromMethods($biDir = false)
     {
         return $this->getRel($biDir);
+    }
+
+    public function morph()
+    {
+        return $this->morphTo();
     }
 }

--- a/tests/TestPolymorphicDualSource.php
+++ b/tests/TestPolymorphicDualSource.php
@@ -2,12 +2,11 @@
 
 namespace AlgoWeb\PODataLaravel\Models;
 
-use AlgoWeb\PODataLaravel\Models\MetadataTrait;
-use Illuminate\Database\Eloquent\Model as Model;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Connection as Connection;
-use Mockery\Mockery;
+use Mockery as m;
 
-class TestMonomorphicManyTarget extends Model
+class TestPolymorphicDualSource extends Model
 {
     use MetadataTrait {
         metadata as traitmetadata; // Need to alias the trait version of the method so we can call it and
@@ -16,8 +15,13 @@ class TestMonomorphicManyTarget extends Model
     }
     protected $metaArray;
     protected $connect;
-    protected $grammar;
-    protected $processor;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = ['*'];
 
     public function __construct(array $meta = null, Connection $connect = null)
     {
@@ -27,14 +31,15 @@ class TestMonomorphicManyTarget extends Model
         if (isset($connect)) {
             $this->connect = $connect;
         } else {
-            $this->processor = \Mockery::mock(\Illuminate\Database\Query\Processors\Processor::class)->makePartial();
-            $this->grammar = \Mockery::mock(\Illuminate\Database\Query\Grammars\Grammar::class)->makePartial();
-            $connect = \Mockery::mock(Connection::class)->makePartial();
-            $connect->shouldReceive('getQueryGrammar')->andReturn($this->grammar);
-            $connect->shouldReceive('getPostProcessor')->andReturn($this->processor);
+            $connect = m::mock(Connection::class)->makePartial();
             $this->connect = $connect;
         }
         parent::__construct();
+    }
+
+    public function getTable()
+    {
+        return 'testmorphonesource';
     }
 
     public function getConnectionName()
@@ -45,11 +50,6 @@ class TestMonomorphicManyTarget extends Model
     public function getConnection()
     {
         return $this->connect;
-    }
-
-    public function manyTarget()
-    {
-        return $this->belongsToMany(TestMonomorphicManySource::class, "target_source", "many_id", "many_source");
     }
 
     public function metadata()
@@ -63,5 +63,15 @@ class TestMonomorphicManyTarget extends Model
     public function getRelationshipsFromMethods($biDir = false)
     {
         return $this->getRel($biDir);
+    }
+
+    public function morphTarget()
+    {
+        return $this->morphOne(TestMorphTarget::class, 'morph');
+    }
+
+    public function morphAlternate()
+    {
+        return $this->morphOne(TestMorphTargetAlternate::class, 'morph');
     }
 }

--- a/tests/unit/Controllers/ODataControllerTest.php
+++ b/tests/unit/Controllers/ODataControllerTest.php
@@ -196,7 +196,7 @@ class ODataControllerTest extends TestCase
         $this->assertFalse($headers->has('Last-Modified'));
         $this->assertFalse($headers->has('Location'));
         $this->assertTrue($headers->has('Status'));
-        $this->assertFalse($headers->has('StatusCode'));
+        $this->assertTrue($headers->has('StatusCode'));
         $this->assertFalse($headers->has('StatusDesc'));
         $this->assertTrue($headers->has('DataServiceVersion'));
     }

--- a/tests/unit/Models/MetadataBidirectionalTest.php
+++ b/tests/unit/Models/MetadataBidirectionalTest.php
@@ -14,11 +14,15 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'many_source' =>
                 [
-                    $targ => [ 'property' => 'manySource', 'local' => 'many_id', 'multiplicity' => '*', 'type' => null]
+                    $targ => [
+                        'manySource' =>
+                            [ 'property' => 'manySource', 'local' => 'many_id', 'multiplicity' => '*', 'type' => null]]
                 ],
             'one_source' =>
                 [
-                    $targ => [ 'property' => 'oneSource', 'local' => 'one_id', 'multiplicity' => '0..1', 'type' => null]
+                    $targ => [
+                        'oneSource' =>
+                            ['property' => 'oneSource', 'local' => 'one_id', 'multiplicity' => '0..1', 'type' => null]]
                 ]
         ];
 
@@ -48,19 +52,23 @@ class MetadataBidirectionalTest extends TestCase
             'many_id' =>
                 [
                     $targ => [
+                        'manyTarget' => [
                         'property' => 'manyTarget',
                         'local' => 'many_source',
                         'multiplicity' => '1',
                         'type' => null
+                            ]
                     ]
                 ],
             'one_id' =>
                 [
                     $targ => [
+                        'oneTarget' => [
                         'property' => 'oneTarget',
                         'local' => 'one_source',
                         'multiplicity' => '1',
                         'type' => null
+                            ]
                     ]
                 ]
         ];
@@ -93,10 +101,12 @@ class MetadataBidirectionalTest extends TestCase
             'many_source' =>
                 [
                     $fooTarg => [
-                        'property' => 'manySource',
-                        'local' => 'many_id',
-                        'multiplicity' => '*',
-                        'type' => null
+                        'manySource' => [
+                            'property' => 'manySource',
+                            'local' => 'many_id',
+                            'multiplicity' => '*',
+                            'type' => null
+                        ]
                     ]
                 ]
         ];
@@ -104,10 +114,12 @@ class MetadataBidirectionalTest extends TestCase
             'many_id' =>
                 [
                     $barTarg => [
-                        'property' => 'manyTarget',
-                        'local' => 'many_source',
-                        'multiplicity' => '*',
-                        'type' => null
+                        'manyTarget' => [
+                            'property' => 'manyTarget',
+                            'local' => 'many_source',
+                            'multiplicity' => '*',
+                            'type' => null
+                        ]
                     ]
                 ]
         ];
@@ -150,7 +162,8 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'morph_id' =>
                 [
-                    $targ => [ 'property' => 'morph', 'local' => 'id', 'multiplicity' => '1', 'type' => 'known']
+                    $targ => [ 'morph' => [
+                        'property' => 'morph', 'local' => 'id', 'multiplicity' => '1', 'type' => 'known']]
                 ]
         ];
 
@@ -180,10 +193,12 @@ class MetadataBidirectionalTest extends TestCase
             'id' =>
                 [
                     $targ => [
+                        'morphTarget' => [
                         'property' => 'morphTarget',
                         'local' => 'morph_id',
                         'multiplicity' => '*',
                         'type' => 'unknown'
+                            ]
                     ]
                 ]
         ];
@@ -214,10 +229,12 @@ class MetadataBidirectionalTest extends TestCase
             'id' =>
                 [
                     $targ => [
+                        'morphTarget' => [
                         'property' => 'morphTarget',
                         'local' => 'morph_id',
                         'multiplicity' => '0..1',
                         'type' => 'unknown'
+                            ]
                     ]
                 ]
         ];
@@ -248,10 +265,12 @@ class MetadataBidirectionalTest extends TestCase
             'source_id' =>
                 [
                     $targ => [
+                        'manySource' => [
                         'property' => 'manySource',
                         'local' => 'target_id',
                         'multiplicity' => '*',
                         'type' => 'unknown'
+                            ]
                     ]
                 ]
         ];
@@ -282,10 +301,12 @@ class MetadataBidirectionalTest extends TestCase
             'target_id' =>
                 [
                     $targ => [
+                        'manyTarget' => [
                         'property' => 'manyTarget',
                         'local' => 'source_id',
                         'multiplicity' => '*',
                         'type' => 'known'
+                            ]
                     ]
                 ]
         ];
@@ -316,12 +337,15 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'one_id' =>
                 [
-                    $targ => ['property' => 'oneTarget', 'local' => 'id', 'multiplicity' => '0..1', 'type' => null],
-                    $twoTarg => ['property' => 'twoTarget', 'local' => 'id', 'multiplicity' => '0..1', 'type' => null]
+                    $targ => ['oneTarget' => [
+                        'property' => 'oneTarget', 'local' => 'id', 'multiplicity' => '0..1', 'type' => null]],
+                    $twoTarg => ['twoTarget' => [
+                        'property' => 'twoTarget', 'local' => 'id', 'multiplicity' => '0..1', 'type' => null]]
                 ],
             'many_id' =>
                 [
-                    $targ => ['property' => 'manyTarget', 'local' => 'id', 'multiplicity' => '*', 'type' => null]
+                    $targ => ['manyTarget' =>
+                        ['property' => 'manyTarget', 'local' => 'id', 'multiplicity' => '*', 'type' => null]]
                 ]
         ];
 
@@ -340,5 +364,29 @@ class MetadataBidirectionalTest extends TestCase
                 $this->assertEquals($expected[$key][$innerKey], $actual[$key][$innerKey]);
             }
         }
+    }
+
+    public function testMonomorphicRelationsKeyedOnSameFieldFromChild()
+    {
+        $foo = new TestMonomorphicOneAndManyTarget();
+        $targ = new TestMonomorphicOneAndManySource();
+        $targName = get_class($targ);
+
+        $expected = [
+            'id' =>
+                [
+                    $targName => ['oneSource' => [
+                            'property' => 'oneSource', 'local' => 'one_id', 'multiplicity' => '1', 'type' => null],
+                        'twoSource' => [
+                            'property' => 'twoSource', 'local' => 'two_id', 'multiplicity' => '1', 'type' => null],
+                        'manySource' => [
+                            'property' => 'manySource', 'local' => 'many_id', 'multiplicity' => '1', 'type' => null]]
+                ]
+        ];
+
+        $actual = $foo->getRelationships();
+        $this->assertTrue(isset($actual));
+        $this->assertTrue(is_array($actual));
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/unit/Models/MetadataBidirectionalTest.php
+++ b/tests/unit/Models/MetadataBidirectionalTest.php
@@ -339,7 +339,10 @@ class MetadataBidirectionalTest extends TestCase
                 [
                     $targ => ['oneTarget' => [
                         'property' => 'oneTarget', 'local' => 'id', 'multiplicity' => '0..1', 'type' => null]],
-                    $twoTarg => ['twoTarget' => [
+                ],
+            'two_id' =>
+                [
+                    $targ => ['twoTarget' => [
                         'property' => 'twoTarget', 'local' => 'id', 'multiplicity' => '0..1', 'type' => null]]
                 ],
             'many_id' =>

--- a/tests/unit/Models/MetadataBidirectionalTest.php
+++ b/tests/unit/Models/MetadataBidirectionalTest.php
@@ -14,11 +14,11 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'many_source' =>
                 [
-                    $targ => [ 'property' => 'manySource', 'local' => 'many_id', 'multiplicity' => '*']
+                    $targ => [ 'property' => 'manySource', 'local' => 'many_id', 'multiplicity' => '*', 'type' => null]
                 ],
             'one_source' =>
                 [
-                    $targ => [ 'property' => 'oneSource', 'local' => 'one_id', 'multiplicity' => '0..1']
+                    $targ => [ 'property' => 'oneSource', 'local' => 'one_id', 'multiplicity' => '0..1', 'type' => null]
                 ]
         ];
 
@@ -47,11 +47,21 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'many_id' =>
                 [
-                    $targ => [ 'property' => 'manyTarget', 'local' => 'many_source', 'multiplicity' => '1']
+                    $targ => [
+                        'property' => 'manyTarget',
+                        'local' => 'many_source',
+                        'multiplicity' => '1',
+                        'type' => null
+                    ]
                 ],
             'one_id' =>
                 [
-                    $targ => [ 'property' => 'oneTarget', 'local' => 'one_source', 'multiplicity' => '1']
+                    $targ => [
+                        'property' => 'oneTarget',
+                        'local' => 'one_source',
+                        'multiplicity' => '1',
+                        'type' => null
+                    ]
                 ]
         ];
 
@@ -82,13 +92,23 @@ class MetadataBidirectionalTest extends TestCase
         $expectedFoo = [
             'many_source' =>
                 [
-                    $fooTarg => [ 'property' => 'manySource', 'local' => 'many_id', 'multiplicity' => '*']
+                    $fooTarg => [
+                        'property' => 'manySource',
+                        'local' => 'many_id',
+                        'multiplicity' => '*',
+                        'type' => null
+                    ]
                 ]
         ];
         $expectedBar = [
             'many_id' =>
                 [
-                    $barTarg => [ 'property' => 'manyTarget', 'local' => 'many_source',  'multiplicity' => '*']
+                    $barTarg => [
+                        'property' => 'manyTarget',
+                        'local' => 'many_source',
+                        'multiplicity' => '*',
+                        'type' => null
+                    ]
                 ]
         ];
 
@@ -130,7 +150,7 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'morph_id' =>
                 [
-                    $targ => [ 'property' => 'morph', 'local' => 'id', 'multiplicity' => '1']
+                    $targ => [ 'property' => 'morph', 'local' => 'id', 'multiplicity' => '1', 'type' => 'known']
                 ]
         ];
 
@@ -159,7 +179,12 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'id' =>
                 [
-                    $targ => [ 'property' => 'morphTarget', 'local' => 'morph_id', 'multiplicity' => '*']
+                    $targ => [
+                        'property' => 'morphTarget',
+                        'local' => 'morph_id',
+                        'multiplicity' => '*',
+                        'type' => 'unknown'
+                    ]
                 ]
         ];
 
@@ -188,7 +213,12 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'id' =>
                 [
-                    $targ => [ 'property' => 'morphTarget', 'local' => 'morph_id', 'multiplicity' => '0..1' ]
+                    $targ => [
+                        'property' => 'morphTarget',
+                        'local' => 'morph_id',
+                        'multiplicity' => '0..1',
+                        'type' => 'unknown'
+                    ]
                 ]
         ];
 
@@ -217,7 +247,12 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'source_id' =>
                 [
-                    $targ => [ 'property' => 'manySource', 'local' => 'target_id', 'multiplicity' => '*']
+                    $targ => [
+                        'property' => 'manySource',
+                        'local' => 'target_id',
+                        'multiplicity' => '*',
+                        'type' => 'unknown'
+                    ]
                 ]
         ];
 
@@ -246,7 +281,12 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'target_id' =>
                 [
-                    $targ => ['property' => 'manyTarget', 'local' => 'source_id', 'multiplicity' => '*']
+                    $targ => [
+                        'property' => 'manyTarget',
+                        'local' => 'source_id',
+                        'multiplicity' => '*',
+                        'type' => 'known'
+                    ]
                 ]
         ];
 
@@ -276,12 +316,12 @@ class MetadataBidirectionalTest extends TestCase
         $expected = [
             'one_id' =>
                 [
-                    $targ => ['property' => 'oneTarget', 'local' => 'id', 'multiplicity' => '0..1'],
-                    $twoTarg => ['property' => 'twoTarget', 'local' => 'id', 'multiplicity' => '0..1']
+                    $targ => ['property' => 'oneTarget', 'local' => 'id', 'multiplicity' => '0..1', 'type' => null],
+                    $twoTarg => ['property' => 'twoTarget', 'local' => 'id', 'multiplicity' => '0..1', 'type' => null]
                 ],
             'many_id' =>
                 [
-                    $targ => ['property' => 'manyTarget', 'local' => 'id', 'multiplicity' => '*']
+                    $targ => ['property' => 'manyTarget', 'local' => 'id', 'multiplicity' => '*', 'type' => null]
                 ]
         ];
 

--- a/tests/unit/Models/MetadataRelationHolderTest.php
+++ b/tests/unit/Models/MetadataRelationHolderTest.php
@@ -1,0 +1,534 @@
+<?php
+
+namespace AlgoWeb\PODataLaravel\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Mockery as m;
+
+class MetadataRelationHolderTest extends TestCase
+{
+    public function testAddBadModel()
+    {
+        $foo = new MetadataRelationHolder();
+        $model = new TestMorphUnexposedTarget();
+
+        $expected = 'Supplied model does not use MetadataTrait';
+        $actual = null;
+
+        try {
+            $foo->addModel($model);
+        } catch (\InvalidArgumentException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testAddGoodModelTwice()
+    {
+        $foo = new MetadataRelationHolder();
+        $model = new TestModel();
+
+        $expected = 'AlgoWeb\PODataLaravel\Models\TestModel already added';
+        $actual = null;
+
+        $foo->addModel($model);
+
+        try {
+            $foo->addModel($model);
+        } catch (\InvalidArgumentException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetRelationsOnMissingModel()
+    {
+        $foo = new MetadataRelationHolder();
+        $model = new TestModel();
+
+        $foo->addModel($model);
+
+        $expected = 'AlgoWeb\PODataLaravel\Models\TestMorphUnexposedTarget does not exist in holder';
+        $actual = null;
+
+        try {
+            $foo->getRelationsByKey(TestMorphUnexposedTarget::class, 'id');
+        } catch (\InvalidArgumentException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetRelationsOnMissingForeignKey()
+    {
+        $foo = new MetadataRelationHolder();
+        $model = new TestModel();
+
+        $foo->addModel($model);
+
+        $expected = 'Key foo_id not registered on AlgoWeb\PODataLaravel\Models\TestModel';
+        $actual = null;
+
+        try {
+            $foo->getRelationsByKey(TestModel::class, 'foo_id');
+        } catch (\InvalidArgumentException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetSingleMonomorphicRelationPair()
+    {
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "manyTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "*",
+            "dependentProp" => "manySource"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMonomorphicOneAndManySource();
+        $targ = new TestMonomorphicOneAndManyTarget();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByKey(TestMonomorphicOneAndManySource::class, 'many_id');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetOneMonomorphicRelationPairOfMany()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "oneTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "oneSource"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMonomorphicOneAndManySource();
+        $targ = new TestMonomorphicOneAndManyTarget();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByKey(TestMonomorphicOneAndManySource::class, 'one_id');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetMonomorphicBelongsToRelations()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "oneTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "oneSource"
+        ];
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "manyTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "*",
+            "dependentProp" => "manySource"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMonomorphicOneAndManyTarget();
+        $targ = new TestMonomorphicOneAndManySource();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByKey(TestMonomorphicOneAndManyTarget::class, 'id');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetMonomorphicManyToMany()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMonomorphicManySource::class,
+            "principalMult" => "*",
+            "principalProp" => "manySource",
+            "dependentType" => TestMonomorphicManyTarget::class,
+            "dependentMult" => "*",
+            "dependentProp" => "manyTarget"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMonomorphicManySource();
+        $targ = new TestMonomorphicManyTarget();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByKey(TestMonomorphicManySource::class, 'many_source');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+
+        $actual = $foo->getRelationsByKey(TestMonomorphicManyTarget::class, 'many_id');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetPolymorphicOneToFooUnknownSide()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMorphOneSource::class,
+            "principalMult" => "1",
+            "principalProp" => "morphTarget",
+            "dependentType" => TestMorphTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "morph"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMorphOneSource();
+        $targ = new TestMorphTarget();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByKey(TestMorphOneSource::class, 'id');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetPolymorphicOneToFooKnownSide()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMorphOneSource::class,
+            "principalMult" => "1",
+            "principalProp" => "morphTarget",
+            "dependentType" => TestMorphTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "morph"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMorphOneSource();
+        $targ = new TestMorphTarget();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByKey(TestMorphTarget::class, 'morph_id');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetPolymorphicManyToManyUnknownSide()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMorphManyToManySource::class,
+            "principalMult" => "*",
+            "principalProp" => "manySource",
+            "dependentType" => TestMorphManyToManyTarget::class,
+            "dependentMult" => "*",
+            "dependentProp" => "manyTarget"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMorphManyToManySource();
+        $targ = new TestMorphManyToManyTarget();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByKey(TestMorphManyToManySource::class, 'source_id');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetPolymorphicManyToManyKnownSide()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMorphManyToManySource::class,
+            "principalMult" => "*",
+            "principalProp" => "manySource",
+            "dependentType" => TestMorphManyToManyTarget::class,
+            "dependentMult" => "*",
+            "dependentProp" => "manyTarget"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMorphManyToManySource();
+        $targ = new TestMorphManyToManyTarget();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByKey(TestMorphManyToManyTarget::class, 'target_id');
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetRelationsByClassMonomorphic()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "oneTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "oneSource"
+        ];
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "manyTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "*",
+            "dependentProp" => "manySource"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $src = new TestMonomorphicOneAndManyTarget();
+        $targ = new TestMonomorphicOneAndManySource();
+
+        $foo->addModel($src);
+        $foo->addModel($targ);
+
+        $actual = $foo->getRelationsByClass(TestMonomorphicOneAndManySource::class);
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetRelationsByClassPolymorphic()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestMorphOneSource::class,
+            "principalMult" => "1",
+            "principalProp" => "morphTarget",
+            "dependentType" => TestMorphTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "morph"
+        ];
+        $expected[] = [
+            "principalType" => TestMorphOneSourceAlternate::class,
+            "principalMult" => "1",
+            "principalProp" => "morphTarget",
+            "dependentType" => TestMorphTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "morph"
+        ];
+        $expected[] = [
+            "principalType" => TestMorphManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "morphTarget",
+            "dependentType" => TestMorphTarget::class,
+            "dependentMult" => "*",
+            "dependentProp" => "morph"
+        ];
+        $expected[] = [
+            "principalType" => TestMorphManySourceAlternate::class,
+            "principalMult" => "1",
+            "principalProp" => "morphTarget",
+            "dependentType" => TestMorphTarget::class,
+            "dependentMult" => "*",
+            "dependentProp" => "morph"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $foo->addModel(new TestMorphTarget());
+        $foo->addModel(new TestMorphOneSourceAlternate());
+        $foo->addModel(new TestMorphOneSource());
+        $foo->addModel(new TestMorphManySource());
+        $foo->addModel(new TestMorphManySourceAlternate());
+
+        $actual = $foo->getRelationsByClass(TestMorphTarget::class);
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetRelationsForDualPolymorphic()
+    {
+        $expected = [];
+        $expected[] = [
+            "principalType" => TestPolymorphicDualSource::class,
+            "principalMult" => "1",
+            "principalProp" => "morphAlternate",
+            "dependentType" => TestMorphTargetAlternate::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "morph"
+        ];
+
+        $foo = new MetadataRelationHolder();
+        $foo->addModel(new TestMorphTarget());
+        $foo->addModel(new TestMorphTargetAlternate());
+        $foo->addModel(new TestPolymorphicDualSource());
+
+        $actual = $foo->getRelationsByClass(TestMorphTargetAlternate::class);
+
+        $this->assertEquals(2 * count($expected), count($actual));
+        foreach ($expected as $forward) {
+            $this->assertTrue(in_array($forward, $actual));
+            $reverse = $forward;
+            $reverse['principalType'] = $forward['dependentType'];
+            $reverse['principalMult'] = $forward['dependentMult'];
+            $reverse['principalProp'] = $forward['dependentProp'];
+            $reverse['dependentType'] = $forward['principalType'];
+            $reverse['dependentMult'] = $forward['principalMult'];
+            $reverse['dependentProp'] = $forward['principalProp'];
+            $this->assertTrue(in_array($reverse, $actual));
+        }
+    }
+
+    public function testGetRelationsByClassBadClass()
+    {
+        $foo = new MetadataRelationHolder();
+        $model = new TestModel();
+
+        $foo->addModel($model);
+
+        $expected = 'AlgoWeb\PODataLaravel\Models\TestMorphUnexposedTarget does not exist in holder';
+        $actual = null;
+
+        try {
+            $foo->getRelationsByClass(TestMorphUnexposedTarget::class);
+        } catch (\InvalidArgumentException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/unit/Models/MetadataRelationHolderTest.php
+++ b/tests/unit/Models/MetadataRelationHolderTest.php
@@ -547,4 +547,42 @@ class MetadataRelationHolderTest extends TestCase
         }
         $this->assertEquals($expected, $actual);
     }
+
+    public function testGetRelationsOnSingleClassWithoutRelations()
+    {
+        $expected = [];
+        $foo = new MetadataRelationHolder();
+        $model = new TestModel();
+
+        $foo->addModel($model);
+
+        $actual = $foo->getRelationsByClass(TestModel::class);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetRelationsOnSingleClassWithRelations()
+    {
+        $expected = [];
+        $foo = new MetadataRelationHolder();
+        $model = new TestMonomorphicManySource();
+
+        $foo->addModel($model);
+
+        $actual = $foo->getRelationsByClass(TestMonomorphicManySource::class);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testGetRelationsFromUnrelatedModels()
+    {
+        $expected = [];
+        $foo = new MetadataRelationHolder();
+        $model = new TestMonomorphicManySource();
+        $bar = new TestMorphOneSourceAlternate();
+
+        $foo->addModel($model);
+        $foo->addModel($bar);
+
+        $actual = $foo->getRelationsByClass(TestMonomorphicManySource::class);
+        $this->assertEquals($expected, $actual);
+    }
 }

--- a/tests/unit/Models/MetadataRelationHolderTest.php
+++ b/tests/unit/Models/MetadataRelationHolderTest.php
@@ -165,6 +165,14 @@ class MetadataRelationHolderTest extends TestCase
             "dependentMult" => "*",
             "dependentProp" => "manySource"
         ];
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "twoTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "twoSource"
+        ];
 
         $foo = new MetadataRelationHolder();
         $src = new TestMonomorphicOneAndManyTarget();
@@ -389,6 +397,14 @@ class MetadataRelationHolderTest extends TestCase
             "dependentType" => TestMonomorphicOneAndManyTarget::class,
             "dependentMult" => "0..1",
             "dependentProp" => "oneSource"
+        ];
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
+            "principalProp" => "twoTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "twoSource"
         ];
         $expected[] = [
             "principalType" => TestMonomorphicOneAndManySource::class,

--- a/tests/unit/Providers/MetadataProviderRelationTest.php
+++ b/tests/unit/Providers/MetadataProviderRelationTest.php
@@ -16,6 +16,8 @@ use AlgoWeb\PODataLaravel\Models\TestMorphManyToManyTarget;
 use AlgoWeb\PODataLaravel\Models\TestMorphOneSource;
 use AlgoWeb\PODataLaravel\Models\TestMorphOneSourceAlternate;
 use AlgoWeb\PODataLaravel\Models\TestMorphTarget;
+use AlgoWeb\PODataLaravel\Models\TestMorphTargetAlternate;
+use AlgoWeb\PODataLaravel\Models\TestPolymorphicDualSource;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Schema;
@@ -127,6 +129,26 @@ class MetadataProviderRelationTest extends TestCase
         $expected[] = [
             "principalType" => TestMorphOneSourceAlternate::class,
             "principalRSet" => TestMorphOneSourceAlternate::class,
+            "principalMult" => "1",
+            "principalProp" => "morphTarget",
+            "dependentType" => TestMorphTarget::class,
+            "dependentRSet" => TestMorphTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "morph"
+        ];
+        $expected[] = [
+            "principalType" => TestPolymorphicDualSource::class,
+            "principalRSet" => TestPolymorphicDualSource::class,
+            "principalMult" => "1",
+            "principalProp" => "morphAlternate",
+            "dependentType" => TestMorphTargetAlternate::class,
+            "dependentRSet" => TestMorphTargetAlternate::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "morph"
+        ];
+        $expected[] = [
+            "principalType" => TestPolymorphicDualSource::class,
+            "principalRSet" => TestPolymorphicDualSource::class,
             "principalMult" => "1",
             "principalProp" => "morphTarget",
             "dependentType" => TestMorphTarget::class,

--- a/tests/unit/Providers/MetadataProviderRelationTest.php
+++ b/tests/unit/Providers/MetadataProviderRelationTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Providers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestCase;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicManySource;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicManyTarget;
@@ -28,7 +29,7 @@ use POData\Providers\Metadata\SimpleMetadataProvider;
 
 class MetadataProviderRelationTest extends TestCase
 {
-    public function testMonomorphicSourceAndTarget()
+    public function testGetAllRelations()
     {
         $app = App::make('app');
         $foo = new MetadataProvider($app);
@@ -90,11 +91,21 @@ class MetadataProviderRelationTest extends TestCase
             "principalType" => TestMonomorphicOneAndManySource::class,
             "principalRSet" => TestMonomorphicOneAndManySource::class,
             "principalMult" => "1",
+            "principalProp" => "twoTarget",
+            "dependentType" => TestMonomorphicOneAndManyTarget::class,
+            "dependentRSet" => TestMonomorphicOneAndManyTarget::class,
+            "dependentMult" => "0..1",
+            "dependentProp" => "twoSource"
+        ];
+        $expected[] = [
+            "principalType" => TestMonomorphicOneAndManySource::class,
+            "principalRSet" => TestMonomorphicOneAndManySource::class,
+            "principalMult" => "1",
             "principalProp" => "manyTarget",
             "dependentType" => TestMonomorphicOneAndManyTarget::class,
             "dependentRSet" => TestMonomorphicOneAndManyTarget::class,
             "dependentMult" => "*",
-            "dependentProp" => "oneSource"
+            "dependentProp" => "manySource"
         ];
         $expected[] = [
             "principalType" => TestMorphManySource::class,
@@ -190,6 +201,7 @@ class MetadataProviderRelationTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMorphOneSource::class, TestMorphOneSourceAlternate::class, TestMorphTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -204,6 +216,8 @@ class MetadataProviderRelationTest extends TestCase
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->once();
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
+        $foo->reset();
 
         $result = $foo->calculateRoundTripRelations();
         $this->assertEquals(4, count($result));
@@ -222,6 +236,7 @@ class MetadataProviderRelationTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMorphManySource::class, TestMorphManySourceAlternate::class, TestMorphTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -236,6 +251,8 @@ class MetadataProviderRelationTest extends TestCase
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->once();
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
+        $foo->reset();
 
         $result = $foo->calculateRoundTripRelations();
         $this->assertEquals(4, count($result));
@@ -254,6 +271,7 @@ class MetadataProviderRelationTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMorphManySource::class, TestMorphManySourceAlternate::class, TestMorphTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -268,6 +286,7 @@ class MetadataProviderRelationTest extends TestCase
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->once();
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
 
         $expected = [];
         $expected[TestMorphTarget::class] = [];
@@ -290,6 +309,7 @@ class MetadataProviderRelationTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -304,6 +324,7 @@ class MetadataProviderRelationTest extends TestCase
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->once();
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
 
         $expected = [];
         $actual = $foo->getPolymorphicRelationGroups();
@@ -323,6 +344,7 @@ class MetadataProviderRelationTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMonomorphicSource::class, TestMonomorphicTarget::class, TestMorphManyToManyTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -337,6 +359,7 @@ class MetadataProviderRelationTest extends TestCase
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->once();
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
 
         $expected = [];
         $actual = $foo->getPolymorphicRelationGroups();
@@ -356,6 +379,7 @@ class MetadataProviderRelationTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMonomorphicSource::class, TestMonomorphicTarget::class, TestMorphManyToManySource::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -370,6 +394,7 @@ class MetadataProviderRelationTest extends TestCase
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->once();
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
 
         $expected = [];
         $actual = $foo->getPolymorphicRelationGroups();
@@ -390,6 +415,7 @@ class MetadataProviderRelationTest extends TestCase
 
         $classen = [ TestMorphManySource::class, TestMorphManySourceAlternate::class, TestMorphTarget::class,
             TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -404,13 +430,14 @@ class MetadataProviderRelationTest extends TestCase
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->atLeast(1);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
 
         $rels = $foo->calculateRoundTripRelations();
         $expected = $foo->calculateRoundTripRelations();
-        $expected[4]['principalRSet'] = 'polyMorphicPlaceholder';
-        $expected[6]['principalRSet'] = 'polyMorphicPlaceholder';
-        $expected[5]['dependentRSet'] = 'polyMorphicPlaceholder';
-        $expected[7]['dependentRSet'] = 'polyMorphicPlaceholder';
+        $expected[0]['principalRSet'] = 'polyMorphicPlaceholder';
+        $expected[3]['principalRSet'] = 'polyMorphicPlaceholder';
+        $expected[1]['dependentRSet'] = 'polyMorphicPlaceholder';
+        $expected[2]['dependentRSet'] = 'polyMorphicPlaceholder';
 
         // if groups is empty, bail right back out - nothing to do
         // else - need to loop through rels
@@ -430,8 +457,10 @@ class MetadataProviderRelationTest extends TestCase
         // yes, this is not actual structure - we're testing that in absence of polymorphic-relation gubbins,
         // raw relations are passed through unmodified
         $expected = ['foo', 'bar'];
+        $holder = new MetadataRelationHolder();
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('calculateRoundTripRelations')->andReturn($expected);
         $foo->shouldReceive('getPolymorphicRelationGroups')->andReturn([]);
         $foo->reset();
@@ -453,6 +482,7 @@ class MetadataProviderRelationTest extends TestCase
         $cacheStore->shouldReceive('get')->withArgs(['metadata'])->andReturn(null)->once();
 
         $classen = [TestMonomorphicManySource::class, TestMonomorphicManyTarget::class];
+        $holder = new MetadataRelationHolder();
 
         $types = [];
 
@@ -475,6 +505,7 @@ class MetadataProviderRelationTest extends TestCase
         $foo->shouldReceive('getCandidateModels')->andReturn($classen);
         $foo->shouldReceive('addResourceSet')->withAnyArgs()->passthru();
         $foo->shouldReceive('getEntityTypesAndResourceSets')->withAnyArgs()->andReturn([$types, null, null]);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
 
         $meta = \Mockery::mock(SimpleMetadataProvider::class)->makePartial();
         $meta->shouldReceive('addEntityType')

--- a/tests/unit/Providers/MetadataProviderRelationTest.php
+++ b/tests/unit/Providers/MetadataProviderRelationTest.php
@@ -82,7 +82,7 @@ class MetadataProviderRelationTest extends TestCase
             "dependentType" => TestMonomorphicOneAndManyTarget::class,
             "dependentRSet" => TestMonomorphicOneAndManyTarget::class,
             "dependentMult" => "0..1",
-            "dependentProp" => "manySource"
+            "dependentProp" => "oneSource"
         ];
         $expected[] = [
             "principalType" => TestMonomorphicOneAndManySource::class,
@@ -92,7 +92,7 @@ class MetadataProviderRelationTest extends TestCase
             "dependentType" => TestMonomorphicOneAndManyTarget::class,
             "dependentRSet" => TestMonomorphicOneAndManyTarget::class,
             "dependentMult" => "*",
-            "dependentProp" => "manySource"
+            "dependentProp" => "oneSource"
         ];
         $expected[] = [
             "principalType" => TestMorphManySource::class,
@@ -137,9 +137,10 @@ class MetadataProviderRelationTest extends TestCase
 
         $actual = $foo->calculateRoundTripRelations();
         $this->assertTrue(is_array($actual), "Bidirectional relations result not an array");
+        $counter = 0;
         $this->assertEquals(2 * count($expected), count($actual));
         foreach ($expected as $forward) {
-            $this->assertTrue(in_array($forward, $actual));
+            $this->assertTrue(in_array($forward, $actual), $counter);
             $reverse = $forward;
             $reverse['principalType'] = $forward['dependentType'];
             $reverse['principalMult'] = $forward['dependentMult'];
@@ -149,7 +150,8 @@ class MetadataProviderRelationTest extends TestCase
             $reverse['dependentMult'] = $forward['principalMult'];
             $reverse['dependentProp'] = $forward['principalProp'];
             $reverse['dependentRSet'] = $forward['principalRSet'];
-            $this->assertTrue(in_array($reverse, $actual));
+            $this->assertTrue(in_array($reverse, $actual), $counter);
+            $counter++;
         }
     }
 

--- a/tests/unit/Providers/MetadataProviderReverseTest.php
+++ b/tests/unit/Providers/MetadataProviderReverseTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Providers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestCase;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicManySource;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicManyTarget;
@@ -39,6 +40,7 @@ class MetadataProviderReverseTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -53,6 +55,7 @@ class MetadataProviderReverseTest extends TestCase
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->atLeast(1);
 
         $foo->boot();
@@ -83,6 +86,7 @@ class MetadataProviderReverseTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMorphManySource::class, TestMorphManySourceAlternate::class, TestMorphTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -97,6 +101,7 @@ class MetadataProviderReverseTest extends TestCase
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->atLeast(1);
 
         $foo->boot();
@@ -128,6 +133,7 @@ class MetadataProviderReverseTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMorphManySource::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -142,6 +148,7 @@ class MetadataProviderReverseTest extends TestCase
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->atLeast(1);
 
         $foo->boot();
@@ -165,6 +172,7 @@ class MetadataProviderReverseTest extends TestCase
         App::instance('metadata', $simple);
 
         $classen = [ TestMorphManySource::class, TestMorphManySourceAlternate::class, TestMorphTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -179,6 +187,7 @@ class MetadataProviderReverseTest extends TestCase
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getIsCaching')->andReturn(false);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('getCandidateModels')->andReturn($classen)->atLeast(1);
 
         $foo->boot();

--- a/tests/unit/Providers/MetadataProviderTest.php
+++ b/tests/unit/Providers/MetadataProviderTest.php
@@ -4,6 +4,7 @@ namespace AlgoWeb\PODataLaravel\Providers;
 
 use AlgoWeb\ODataMetadata\MetadataManager;
 use AlgoWeb\ODataMetadata\MetadataV3\edm\TEntityTypeType;
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestCase as TestCase;
 use AlgoWeb\PODataLaravel\Models\TestCastModel;
 use AlgoWeb\PODataLaravel\Models\TestGetterModel;
@@ -128,6 +129,7 @@ class MetadataProviderTest extends TestCase
             TestMonomorphicOneAndManyTarget::class, TestCastModel::class, TestMorphOneSourceAlternate::class,
             TestMorphManySourceAlternate::class, TestMorphManySourceWithUnexposedTarget::class,
             TestPolymorphicDualSource::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = m::mock($className)->makePartial();
@@ -144,6 +146,7 @@ class MetadataProviderTest extends TestCase
         Cache::swap($cache);
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('getIsCaching')->andReturn(true)->once();
 
         $foo->boot();
@@ -160,6 +163,7 @@ class MetadataProviderTest extends TestCase
         App::instance(TestModel::class, $testModel);
 
         $this->setUpSchemaFacade();
+        $holder = new MetadataRelationHolder();
 
         //$meta = \Mockery::mock(SimpleMetadataProvider::class)->makePartial();
         $meta = new SimpleMetadataProvider('Data', 'Data');
@@ -172,6 +176,7 @@ class MetadataProviderTest extends TestCase
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getCandidateModels')->andReturn([TestModel::class]);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('addResourceSet')->withAnyArgs()->passthru();
 
         $foo->boot();
@@ -197,6 +202,7 @@ class MetadataProviderTest extends TestCase
         $this->setUpSchemaFacade();
 
         $abstract = $this->createAbstractMockType();
+        $holder = new MetadataRelationHolder();
 
         $meta = \Mockery::mock(SimpleMetadataProvider::class)->makePartial();
         $meta->shouldReceive('addEntityType')->andReturn($abstract)->once();
@@ -207,6 +213,7 @@ class MetadataProviderTest extends TestCase
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getCandidateModels')->andReturn([TestModel::class]);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('addResourceSet')->withAnyArgs()->passthru();
 
         $foo->boot();
@@ -226,6 +233,7 @@ class MetadataProviderTest extends TestCase
         $classen = [TestMonomorphicOneAndManySource::class, TestMonomorphicOneAndManyTarget::class,
             TestMorphManyToManyTarget::class, TestMorphManyToManySource::class, TestMonomorphicSource::class,
             TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
 
         $types = [];
 
@@ -246,6 +254,7 @@ class MetadataProviderTest extends TestCase
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getCandidateModels')->andReturn($classen);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('addResourceSet')->withAnyArgs()->passthru();
         $foo->shouldReceive('getEntityTypesAndResourceSets')->withAnyArgs()->andReturn([$types, null, null]);
 
@@ -279,6 +288,7 @@ class MetadataProviderTest extends TestCase
         $cacheStore->shouldReceive('get')->withArgs(['metadata'])->andReturn(null)->once();
 
         $classen = [TestMorphManySource::class, TestMorphTarget::class];
+        $holder = new MetadataRelationHolder();
 
         $types = [];
         $i = 0;
@@ -298,6 +308,7 @@ class MetadataProviderTest extends TestCase
 
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getCandidateModels')->andReturn($classen);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->shouldReceive('addResourceSet')->withAnyArgs()->passthru();
         $foo->shouldReceive('getEntityTypesAndResourceSets')->withAnyArgs()->andReturn([$types, null, null]);
 
@@ -344,6 +355,7 @@ class MetadataProviderTest extends TestCase
             TestMonomorphicSource::class, TestMonomorphicTarget::class, TestMorphManyToManySource::class,
             TestMorphManyToManyTarget::class, TestMonomorphicOneAndManySource::class,
             TestMonomorphicOneAndManyTarget::class];
+        $holder = new MetadataRelationHolder();
 
         $types = [];
         $i = 0;
@@ -360,6 +372,7 @@ class MetadataProviderTest extends TestCase
         $app = App::make('app');
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getCandidateModels')->andReturn($classen);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->boot();
 
         $meta = App::make('metadata');
@@ -396,10 +409,12 @@ class MetadataProviderTest extends TestCase
         $auth->shouldReceive('user')->andReturn($testModel)->once();
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
 
         $app = App::make('app');
         $foo = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $foo->shouldReceive('getCandidateModels')->andReturn($classen);
+        $foo->shouldReceive('getRelationHolder')->andReturn($holder);
         $foo->boot();
 
         $meta = App::make('metadata');

--- a/tests/unit/Providers/MetadataProviderTest.php
+++ b/tests/unit/Providers/MetadataProviderTest.php
@@ -21,6 +21,8 @@ use AlgoWeb\PODataLaravel\Models\TestMorphManyToManyTarget;
 use AlgoWeb\PODataLaravel\Models\TestMorphOneSource;
 use AlgoWeb\PODataLaravel\Models\TestMorphOneSourceAlternate;
 use AlgoWeb\PODataLaravel\Models\TestMorphTarget;
+use AlgoWeb\PODataLaravel\Models\TestMorphTargetAlternate;
+use AlgoWeb\PODataLaravel\Models\TestPolymorphicDualSource;
 use Illuminate\Cache\ArrayStore;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\App;
@@ -122,9 +124,10 @@ class MetadataProviderTest extends TestCase
         $classen = [TestModel::class, TestGetterModel::class, TestMorphManySource::class, TestMorphOneSource::class,
             TestMorphTarget::class, TestMonomorphicManySource::class, TestMonomorphicManyTarget::class,
             TestMonomorphicSource::class, TestMonomorphicTarget::class, TestMorphManyToManySource::class,
-            TestMorphManyToManyTarget::class, TestMonomorphicOneAndManySource::class,
+            TestMorphManyToManyTarget::class, TestMonomorphicOneAndManySource::class, TestMorphTargetAlternate::class,
             TestMonomorphicOneAndManyTarget::class, TestCastModel::class, TestMorphOneSourceAlternate::class,
-            TestMorphManySourceAlternate::class, TestMorphManySourceWithUnexposedTarget::class];
+            TestMorphManySourceAlternate::class, TestMorphManySourceWithUnexposedTarget::class,
+            TestPolymorphicDualSource::class];
 
         foreach ($classen as $className) {
             $testModel = m::mock($className)->makePartial();

--- a/tests/unit/Serialisers/IronicSerialiserTest.php
+++ b/tests/unit/Serialisers/IronicSerialiserTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Serialisers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicManySource;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicManyTarget;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicSource;
@@ -414,6 +415,7 @@ class IronicSerialiserTest extends SerialiserTestBase
         App::instance('metadata', $simple);
 
         $classen = [ TestMorphOneSource::class, TestMorphOneSourceAlternate::class, TestMorphTarget::class];
+        $holder = new MetadataRelationHolder();
 
         foreach ($classen as $className) {
             $testModel = new $className($meta);
@@ -422,6 +424,7 @@ class IronicSerialiserTest extends SerialiserTestBase
 
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $propContent = new ODataPropertyContent();
@@ -551,8 +554,11 @@ class IronicSerialiserTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicManySource::class, TestMonomorphicManyTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -611,8 +617,11 @@ class IronicSerialiserTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $targ = new TestMonomorphicTarget($metadata);

--- a/tests/unit/Serialisers/SerialiserWriteBagTest.php
+++ b/tests/unit/Serialisers/SerialiserWriteBagTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Serialisers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestModel;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicTarget;
 use AlgoWeb\PODataLaravel\Providers\MetadataProvider;
@@ -311,6 +312,8 @@ class SerialiserWriteBagTest extends SerialiserTestBase
      */
     private function setUpDataServiceDeps($request)
     {
+        $holder = new MetadataRelationHolder();
+
         $metadata = [];
         $metadata['id'] = ['type' => 'integer', 'nullable' => false, 'fillable' => false, 'default' => null];
         $metadata['name'] = ['type' => 'string', 'nullable' => false, 'fillable' => true, 'default' => null];
@@ -325,6 +328,7 @@ class SerialiserWriteBagTest extends SerialiserTestBase
         $classen = [TestModel::class];
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');

--- a/tests/unit/Serialisers/SerialiserWriteComplexTest.php
+++ b/tests/unit/Serialisers/SerialiserWriteComplexTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Serialisers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestModel;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicTarget;
 use AlgoWeb\PODataLaravel\Providers\MetadataProvider;
@@ -376,6 +377,8 @@ class SerialiserWriteComplexTest extends SerialiserTestBase
      */
     private function setUpDataServiceDeps($request)
     {
+        $holder = new MetadataRelationHolder();
+
         $metadata = [];
         $metadata['id'] = ['type' => 'integer', 'nullable' => false, 'fillable' => false, 'default' => null];
         $metadata['name'] = ['type' => 'string', 'nullable' => false, 'fillable' => true, 'default' => null];
@@ -390,6 +393,7 @@ class SerialiserWriteComplexTest extends SerialiserTestBase
         $classen = [TestModel::class];
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');

--- a/tests/unit/Serialisers/SerialiserWriteElementTest.php
+++ b/tests/unit/Serialisers/SerialiserWriteElementTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Serialisers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestModel;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicManySource;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicManyTarget;
@@ -60,8 +61,11 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -115,8 +119,11 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -178,8 +185,11 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -234,8 +244,11 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -293,8 +306,11 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -390,8 +406,11 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -455,8 +474,11 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicManySource::class, TestMonomorphicManyTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -542,8 +564,11 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');

--- a/tests/unit/Serialisers/SerialiserWriteElementsTest.php
+++ b/tests/unit/Serialisers/SerialiserWriteElementsTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Serialisers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestModel;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicSource;
 use AlgoWeb\PODataLaravel\Models\TestMonomorphicTarget;
@@ -48,8 +49,11 @@ class SerialiserWriteElementsTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -101,8 +105,11 @@ class SerialiserWriteElementsTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -156,8 +163,11 @@ class SerialiserWriteElementsTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -215,8 +225,11 @@ class SerialiserWriteElementsTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestMonomorphicSource::class, TestMonomorphicTarget::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $belongsTo = m::mock(BelongsTo::class)->makePartial();
@@ -283,8 +296,11 @@ class SerialiserWriteElementsTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');

--- a/tests/unit/Serialisers/SerialiserWritePrimitiveTest.php
+++ b/tests/unit/Serialisers/SerialiserWritePrimitiveTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Serialisers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestModel;
 use AlgoWeb\PODataLaravel\Providers\MetadataProvider;
 use AlgoWeb\PODataLaravel\Query\LaravelQuery;
@@ -267,6 +268,7 @@ class SerialiserWritePrimitiveTest extends SerialiserTestBase
      */
     private function setUpDataServiceDeps($request)
     {
+        $holder = new MetadataRelationHolder();
         $metadata = [];
         $metadata['id'] = ['type' => 'integer', 'nullable' => false, 'fillable' => false, 'default' => null];
         $metadata['name'] = ['type' => 'string', 'nullable' => false, 'fillable' => true, 'default' => null];
@@ -281,6 +283,7 @@ class SerialiserWritePrimitiveTest extends SerialiserTestBase
         $classen = [TestModel::class];
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');

--- a/tests/unit/Serialisers/SerialiserWriteUrlTest.php
+++ b/tests/unit/Serialisers/SerialiserWriteUrlTest.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Serialisers;
 
+use AlgoWeb\PODataLaravel\Models\MetadataRelationHolder;
 use AlgoWeb\PODataLaravel\Models\TestCase as TestCase;
 use AlgoWeb\PODataLaravel\Models\TestModel;
 use AlgoWeb\PODataLaravel\Providers\MetadataProvider;
@@ -37,8 +38,11 @@ class SerialiserWriteUrlTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -83,8 +87,11 @@ class SerialiserWriteUrlTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');
@@ -134,8 +141,11 @@ class SerialiserWriteUrlTest extends SerialiserTestBase
         $host->setServiceUri("/odata.svc/");
 
         $classen = [TestModel::class];
+        $holder = new MetadataRelationHolder();
+
         $metaProv = m::mock(MetadataProvider::class)->makePartial()->shouldAllowMockingProtectedMethods();
         $metaProv->shouldReceive('getCandidateModels')->andReturn($classen);
+        $metaProv->shouldReceive('getRelationHolder')->andReturn($holder);
         $metaProv->boot();
 
         $meta = App::make('metadata');


### PR DESCRIPTION
This fixes a long-standing oversight where multiple relations between two models, keyed on the same field, were not properly retrieved, as the last-processed such overwrote the earlier one(s).