### PR TITLE
Fix PrimaryKey substitution in LaravelReadQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+   * Fix orderBy handling, whether via model, relation or query builder
 
 0.3.0 (2017-09-24)
 ------------------

--- a/src/Query/LaravelReadQuery.php
+++ b/src/Query/LaravelReadQuery.php
@@ -96,7 +96,7 @@ class LaravelReadQuery
             foreach ($orderBy->getOrderByInfo()->getOrderByPathSegments() as $order) {
                 foreach ($order->getSubPathSegments() as $subOrder) {
                     $subName = $subOrder->getName();
-                    $subName = (self::PK == $subName) ? $sourceEntityInstance->getKeyName() : $subName;
+                    $subName = (self::PK == $subName) ? $keyName : $subName;
                     $sourceEntityInstance = $sourceEntityInstance->orderBy(
                         $subName,
                         $order->isAscending() ? 'asc' : 'desc'


### PR DESCRIPTION
When applying a non-trivial orderBy object that contained PrimaryKey
field, getResourceSet was ignoring previously-retrieved copy of target
model's primary key and trying to dig it out anew.  This doesn't work
too well on query builders, as getKeyName doesn't exist.

The simple and obvious fix is to simply cut the orderBy handling over
to use the previously-retrieved copy of keyName, and let it worry about
whether we're hanging off a model, relation, etc.