### PR TITLE
Serialise literal PrimaryKey field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+   * Fix bug that omitted PrimaryKey property serialisation
    * Fix orderBy handling, whether via model, relation or query builder
 
 0.3.0 (2017-09-24)

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -8,6 +8,7 @@ use AlgoWeb\PODataLaravel\Models\ObjectMap\Entities\EntityField;
 use AlgoWeb\PODataLaravel\Models\ObjectMap\Entities\EntityFieldPrimitiveType;
 use AlgoWeb\PODataLaravel\Models\ObjectMap\Entities\EntityFieldType;
 use AlgoWeb\PODataLaravel\Models\ObjectMap\Entities\EntityGubbins;
+use AlgoWeb\PODataLaravel\Query\LaravelReadQuery;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -690,5 +691,14 @@ trait MetadataTrait
         $gubbins->setStubs($stubs);
 
         return $gubbins;
+    }
+
+    public function synthLiteralPK()
+    {
+        if (!$this->isKnownPolymorphSide()) {
+            return;
+        }
+        $fieldName = LaravelReadQuery::PK;
+        $this->$fieldName = $this->getKey();
     }
 }

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Mockery\Mock;
 use POData\Providers\Metadata\Type\EdmPrimitiveType;
 
 trait MetadataTrait
@@ -195,11 +196,14 @@ trait MetadataTrait
             if (!empty($methods)) {
                 foreach ($methods as $method) {
                     if (!method_exists('Illuminate\Database\Eloquent\Model', $method)
+                        && !method_exists(Mock::class, $method)
+                        && !method_exists(MetadataTrait::class, $method)
                     ) {
                         //Use reflection to inspect the code, based on Illuminate/Support/SerializableClosure.php
                         $reflection = new \ReflectionMethod($model, $method);
+                        $fileName = $reflection->getFileName();
 
-                        $file = new \SplFileObject($reflection->getFileName());
+                        $file = new \SplFileObject($fileName);
                         $file->seek($reflection->getStartLine()-1);
                         $code = '';
                         while ($file->key() < $reflection->getEndLine()) {

--- a/src/Serialisers/IronicSerialiser.php
+++ b/src/Serialisers/IronicSerialiser.php
@@ -162,6 +162,7 @@ class IronicSerialiser implements IObjectSerialiser
         $topOfStack = $this->lightStack[$stackCount-1];
         $payloadClass = get_class($entryObject->results);
         $resourceType = $this->getService()->getProvidersWrapper()->resolveResourceType($topOfStack['type']);
+
         // need gubbinz to unpack an abstract resource type
         if ($resourceType->isAbstract()) {
             $derived = $this->getMetadata()->getDerivedTypes($resourceType);
@@ -843,7 +844,7 @@ class IronicSerialiser implements IObjectSerialiser
      * @param $nonRelProp
      * @return ODataPropertyContent
      */
-    private function writePrimitiveProperties($entryObject, $nonRelProp)
+    private function writePrimitiveProperties(Model $entryObject, $nonRelProp)
     {
         $propertyContent = new ODataPropertyContent();
         $cereal = $this->getModelSerialiser()->bulkSerialise($entryObject);

--- a/src/Serialisers/ModelSerialiser.php
+++ b/src/Serialisers/ModelSerialiser.php
@@ -33,6 +33,7 @@ class ModelSerialiser
         if (!isset(self::$metadataCache[$class])) {
             self::$metadataCache[$class] = $model->metadata();
         }
+        $model->synthLiteralPK();
         $meta = self::$metadataCache[$class];
         $keys = array_keys($meta);
         // dig up getter list - we only care about the mutators that end up in metadata

--- a/src/Serialisers/ModelSerialiser.php
+++ b/src/Serialisers/ModelSerialiser.php
@@ -2,6 +2,7 @@
 
 namespace AlgoWeb\PODataLaravel\Serialisers;
 
+use AlgoWeb\PODataLaravel\Query\LaravelReadQuery;
 use Illuminate\Database\Eloquent\Model;
 
 class ModelSerialiser
@@ -47,7 +48,8 @@ class ModelSerialiser
             self::$mutatorCache[$class] = $getterz;
         }
         $getterz = self::$mutatorCache[$class];
-        $result = array_intersect_key($model->getAttributes(), $meta);
+        $modelAttrib = $model->getAttributes();
+        $result = array_intersect_key($modelAttrib, $meta);
         foreach ($keys as $key) {
             if (!isset($result[$key])) {
                 $result[$key] = null;
@@ -55,6 +57,9 @@ class ModelSerialiser
         }
         foreach ($getterz as $getter) {
             $result[$getter] = $model->$getter;
+        }
+        if (isset($modelAttrib[LaravelReadQuery::PK])) {
+            $result[LaravelReadQuery::PK] = $modelAttrib[LaravelReadQuery::PK];
         }
 
         return $result;

--- a/tests/unit/Models/MetadataTraitTest.php
+++ b/tests/unit/Models/MetadataTraitTest.php
@@ -503,4 +503,20 @@ class MetadataTraitTest extends TestCase
             [TestMorphManySourceWithUnexposedTarget::class, false]
         ];
     }
+
+    public function testSynthLiteralPKNotOnUnknownSide()
+    {
+        $foo = new TestModel();
+        $foo->id = 42;
+        $foo->synthLiteralPK();
+        $this->assertEquals(null, $foo->PrimaryKey);
+    }
+
+    public function testSynthLiteralPKOnUnknownSide()
+    {
+        $foo = new TestMorphManySource();
+        $foo->id = 42;
+        $foo->synthLiteralPK();
+        $this->assertEquals(42, $foo->PrimaryKey);
+    }
 }

--- a/tests/unit/Serialisers/IronicSerialiserTest.php
+++ b/tests/unit/Serialisers/IronicSerialiserTest.php
@@ -429,12 +429,19 @@ class IronicSerialiserTest extends SerialiserTestBase
         $metaProv->boot();
 
         $propContent = new ODataPropertyContent();
-        $propContent->properties = ['name' => new ODataProperty(), 'alternate_id' => new ODataProperty()];
+        $propContent->properties = [
+            'name' => new ODataProperty(),
+            'alternate_id' => new ODataProperty(),
+            'PrimaryKey' => new ODataProperty()
+        ];
         $propContent->properties['name']->name = 'name';
         $propContent->properties['alternate_id']->name = 'alternate_id';
+        $propContent->properties['PrimaryKey']->name = 'PrimaryKey';
         $propContent->properties['name']->typeName = 'Edm.String';
         $propContent->properties['alternate_id']->typeName = 'Edm.Int32';
+        $propContent->properties['PrimaryKey']->typeName = 'Edm.String';
         $propContent->properties['name']->value = 'Hammer, M.C.';
+        $propContent->properties['PrimaryKey']->value = '42';
 
         $odataLink = new ODataLink();
         $odataLink->name = 'http://schemas.microsoft.com/ado/2007/08/dataservices/related/morph';
@@ -478,7 +485,6 @@ class IronicSerialiserTest extends SerialiserTestBase
         $model = new TestMorphTarget($meta);
         $model->id = 42;
         $model->name = 'Hammer, M.C.';
-        $model->PrimaryKey = 42;
         $this->assertTrue($model->isKnownPolymorphSide());
         $this->assertTrue($model->isUnknownPolymorphSide());
 

--- a/tests/unit/Serialisers/SerialiserWriteElementTest.php
+++ b/tests/unit/Serialisers/SerialiserWriteElementTest.php
@@ -829,6 +829,8 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $source = new TestMonomorphicParentOfMorphTarget($metadata);
         $target = new TestMorphTarget($metadata);
 
+        $relMethods = $source->getRelationshipsFromMethods();
+
         App::instance(TestMonomorphicParentOfMorphTarget::class, $source);
         App::instance(TestMorphTarget::class, $target);
 
@@ -884,6 +886,7 @@ class SerialiserWriteElementTest extends SerialiserTestBase
         $model = m::mock(TestMonomorphicParentOfMorphTarget::class)->makePartial()
             ->shouldAllowMockingProtectedMethods();
         $model->shouldReceive('metadata')->andReturn($metadata);
+        $model->shouldReceive('getRelationshipsFromMethods')->andReturn($relMethods);
         $model->id = 1;
         $model->name = 'Name';
         $model->shouldReceive('getAttribute')->withArgs(['morphTargets'])->andReturn(collect([$targ1, $targ2]));


### PR DESCRIPTION
We were previously doing everything for PK property and value generation except spitting it out to wire.  Now we're spitting out to wire, too.

This enables OData clients to read unknown-side polymorphic-affected models - previously, lacking the PrimaryKey field, they couldn't read it, as key value was missing in action.