### PR TITLE
Fix eager loads on singletons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 ----------
+   * Eager-load explicitly-expanded properties during GET queries
+   * Memoise repeated calculations to speed up big GET queries
    * Fix bug that omitted PrimaryKey property serialisation
    * Fix orderBy handling, whether via model, relation or query builder
 

--- a/src/Query/LaravelReadQuery.php
+++ b/src/Query/LaravelReadQuery.php
@@ -323,12 +323,13 @@ class LaravelReadQuery
         }
 
         $this->checkAuth($sourceEntityInstance);
+        $modelLoad = $sourceEntityInstance->getEagerLoad();
 
         $this->processKeyDescriptor($sourceEntityInstance, $keyDescriptor);
         foreach ($whereCondition as $fieldName => $fieldValue) {
             $sourceEntityInstance = $sourceEntityInstance->where($fieldName, $fieldValue);
         }
-        $modelLoad = $sourceEntityInstance->getEagerLoad();
+
         $rawLoad = array_values(array_unique(array_merge($rawLoad, $modelLoad)));
         $sourceEntityInstance = $sourceEntityInstance->get();
         $sourceCount = $sourceEntityInstance->count();


### PR DESCRIPTION
Attempts to fix #127 .
Previous code worked fine when no where conditions were being added, but some wombat tripped over what happens when you chain any sort of clause onto an Eloquent model (it returns a query builder, not an Eloquent model)