### PR TITLE
Skip non-tabled models when booting under php artisan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+   * Fix bug that stopped migration attempts
    * Eager-load explicitly-expanded properties during GET queries
    * Memoise repeated calculations to speed up big GET queries
    * Fix bug that omitted PrimaryKey property serialisation

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\App;
 use Mockery\Mock;
 use POData\Providers\Metadata\Type\EdmPrimitiveType;
 
@@ -669,7 +670,10 @@ trait MetadataTrait
             $nuField->setPrimitiveType(new EntityFieldPrimitiveType($field['type']));
             $entityFields[$name] = $nuField;
         }
-        $gubbins->setFields($entityFields);
+        $isEmpty = (0 === count($entityFields));
+        if (!($isEmpty && $this->isRunningInArtisan())) {
+            $gubbins->setFields($entityFields);
+        }
 
         $rawRels = $this->getRelationships();
         $stubs = [];
@@ -704,5 +708,10 @@ trait MetadataTrait
         }
         $fieldName = LaravelReadQuery::PK;
         $this->$fieldName = $this->getKey();
+    }
+
+    public function isRunningInArtisan()
+    {
+        return App::runningInConsole() && !App::runningUnitTests();
     }
 }

--- a/src/Models/ObjectMap/Map.php
+++ b/src/Models/ObjectMap/Map.php
@@ -11,7 +11,7 @@ class Map
     /**
      * @var EntityGubbins[]
      */
-    private $entities;
+    private $entities = [];
 
     /**
      * @var Association[]
@@ -23,9 +23,6 @@ class Map
      */
     public function addEntity(EntityGubbins $entity)
     {
-        if (!is_array($this->entities)) {
-            $this->entities = [];
-        }
         $this->entities[$entity->getClassName()] = $entity;
     }
 

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -82,7 +82,12 @@ class MetadataProvider extends MetadataBaseProvider
         $objectMap = new Map();
         foreach ($modelNames as $modelName) {
             $modelInstance = App::make($modelName);
-            $objectMap->addEntity($modelInstance->extractGubbins());
+            $gubbins = $modelInstance->extractGubbins();
+            $isEmpty = 0 === count($gubbins->getFields());
+            $inArtisan = $this->isRunningInArtisan();
+            if (!($isEmpty && $inArtisan)) {
+                $objectMap->addEntity($gubbins);
+            }
         }
         if (null != self::$afterExtract) {
             $func = self::$afterExtract;
@@ -429,5 +434,10 @@ class MetadataProvider extends MetadataBaseProvider
             }
         }
         return null;
+    }
+
+    public function isRunningInArtisan()
+    {
+        return App::runningInConsole() && !App::runningUnitTests();
     }
 }

--- a/tests/TestCastModel.php
+++ b/tests/TestCastModel.php
@@ -22,6 +22,7 @@ class TestCastModel extends Model
     protected $processor;
 
     protected $casts = ['is_bool' => 'boolean'];
+    protected $isArtisan = null;
 
     public function __construct(array $meta = null, $endpoint = null)
     {

--- a/tests/TestModel.php
+++ b/tests/TestModel.php
@@ -15,12 +15,14 @@ class TestModel extends Model
     use MetadataTrait {
         metadata as traitmetadata; // Need to alias the trait version of the method so we can call it and
         // not bury ourselves under a stack overflow and segfault
+        isRunningInArtisan as isArtisan;
     }
 
     protected $metaArray;
     protected $connect;
     protected $grammar;
     protected $processor;
+    protected $isArtisan;
 
     public function __construct(array $meta = null, $endpoint = null)
     {
@@ -91,6 +93,15 @@ class TestModel extends Model
         }
     }
 
+
+    public function setArtisan($value)
+    {
+        if (null === $value) {
+            $this->isArtisan = null;
+        }
+        $this->isArtisan = boolval($value);
+    }
+
     public function metadata()
     {
         if (isset($this->metaArray)) {
@@ -147,5 +158,13 @@ class TestModel extends Model
         if (empty($this->query->orders) && empty($this->query->unionOrders)) {
             $this->orderBy($this->model->getQualifiedKeyName(), 'asc');
         }
+    }
+
+    public function isRunningInArtisan()
+    {
+        if (null !== $this->isArtisan) {
+            return $this->isArtisan;
+        }
+        return $this->isArtisan();
     }
 }

--- a/tests/unit/Providers/MetadataProviderNewTest.php
+++ b/tests/unit/Providers/MetadataProviderNewTest.php
@@ -447,6 +447,50 @@ class MetadataProviderNewTest extends TestCase
         $this->assertEquals(null, Cache::get($key));
     }
 
+    public function testEmptyGubbinsNotUnderArtisan()
+    {
+        $expected = 'Fields array must not be empty';
+        $actual = null;
+        $meta = [];
+
+        $testModel = new TestModel($meta, null);
+        $testModel->name = 'Commence Primary Ignition';
+
+        App::instance(TestModel::class, $testModel);
+        $classen = [TestModel::class];
+        $this->setUpSchemaFacade();
+
+        $foo = $this->object;
+        $foo->shouldReceive('getCandidateModels')->andReturn($classen);
+
+        try {
+            $foo->boot();
+        } catch (\Exception $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testEmptyGubbinsUnderArtisan()
+    {
+        $meta = [];
+
+        $testModel = new TestModel($meta, null);
+        $testModel->name = 'Commence Primary Ignition';
+        $testModel->setArtisan(true);
+
+        App::instance(TestModel::class, $testModel);
+        $classen = [TestModel::class];
+        $this->setUpSchemaFacade();
+
+        $foo = $this->object;
+        $foo->shouldReceive('getCandidateModels')->andReturn($classen);
+        $foo->shouldReceive('isRunningInArtisan')->andReturn(true);
+        $foo->boot();
+        $map = $foo->getObjectMap();
+        $this->assertEquals(0, count($map->getEntities()));
+    }
+
     private function setUpSchemaFacade()
     {
         $schema = Schema::getFacadeRoot();


### PR DESCRIPTION
Previously, models that had empty fields (because of an empty or
non-existent DB table) would cause application boot to blow up unconditionally.

This included attempts to run php artisan migrate and thus _fix_ the lack of
table - resulting in a deadlock that had to be resolved by manually editing
the model in question, migrating, and then reversing the edit.

Now, such empty models are simply skipped when running under artisan, allowing
migrate commands to be run and fix lack-of-table problem.