### PR TITLE
Hook metadata mask up to getter processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Unreleased
 ----------
+   * Respect hidden/visible getters in metadata processing
+   * Require property names to be case-insensitive unique
    * Fix bug that stopped migration attempts
    * Eager-load explicitly-expanded properties during GET queries
    * Memoise repeated calculations to speed up big GET queries

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -54,6 +54,7 @@ trait MetadataTrait
         $rawFoo = $connect->getDoctrineSchemaManager()->listTableColumns($table);
         $foo = [];
         $getters = $this->collectGetters();
+        $getters = array_intersect($getters, $mask);
 
         foreach ($rawFoo as $key => $val) {
             // Work around glitch in Doctrine when reading from MariaDB which added ` characters to root key value

--- a/tests/unit/Models/MetadataTraitExtractionTest.php
+++ b/tests/unit/Models/MetadataTraitExtractionTest.php
@@ -4,6 +4,13 @@ namespace AlgoWeb\PODataLaravel\Models;
 
 use AlgoWeb\PODataLaravel\Models\ObjectMap\Entities\Associations\AssociationStubPolymorphic;
 use AlgoWeb\PODataLaravel\Models\ObjectMap\Entities\Associations\AssociationStubRelationType as RelType;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Types\StringType;
+use Doctrine\DBAL\Types\Type;
+use Illuminate\Database\Connection;
+use Illuminate\Database\Schema\Blueprint;
+use Mockery as m;
 
 class MetadataTraitExtractionTest extends TestCase
 {
@@ -113,6 +120,54 @@ class MetadataTraitExtractionTest extends TestCase
         } catch (\Exception $e) {
             $actual = $e->getMessage();
         }
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testExcludedGetterIsActuallyExcluded()
+    {
+        $expected = [];
+        $expected['name'] = ['type' => 'string', 'nullable' => false, 'fillable' => true, 'default' => 'name'];
+        $expected['added_at'] =
+            ['type' => 'string', 'nullable' => false, 'fillable' => true, 'default' => '2017-10-11T00:00:00'];
+        $expected['weight'] = ['type' => 'string', 'nullable' => false, 'fillable' => true, 'default' => '100'];
+        $expected['code'] = ['type' => 'string', 'nullable' => false, 'fillable' => true, 'default' => 'code'];
+
+        $type = m::mock(StringType::class)->makePartial();
+
+        $name = m::mock(Column::class)->makePartial();
+        $name->shouldReceive('getType')->andReturn($type)->atLeast(1);
+        $addedAt = m::mock(Column::class)->makePartial();
+        $addedAt->shouldReceive('getType')->andReturn($type)->atLeast(1);
+        $weight = m::mock(Column::class)->makePartial();
+        $weight->shouldReceive('getType')->andReturn($type)->atLeast(1);
+        $code = m::mock(Column::class)->makePartial();
+        $code->shouldReceive('getType')->andReturn($type)->atLeast(1);
+
+        $rawColumns = ['name' => $name, 'added_at' => $addedAt, 'weight' => $weight, 'code' => $code];
+
+        $manager = m::mock(AbstractSchemaManager::class)->makePartial();
+        $manager->shouldReceive('listTableColumns')->andReturn($rawColumns)->atLeast(1);
+
+        $columns = [ 'name', 'added_at', 'weight', 'code'];
+
+        $builder = m::mock(Blueprint::class)->makePartial();
+        $builder->shouldReceive('hasTable')->andReturn(true)->atLeast(1);
+        $builder->shouldReceive('getColumnListing')->andReturn($columns)->atLeast(1);
+
+        $connect = m::mock(Connection::class)->makePartial();
+        $connect->shouldReceive('getSchemaBuilder')->andReturn($builder);
+        $connect->shouldReceive('getDoctrineSchemaManager')->andReturn($manager)->atLeast(1);
+
+        $foo = m::mock(TestGetterModel::class)->makePartial()->shouldAllowMockingProtectedMethods();
+        $foo->shouldReceive('getConnection')->andReturn($connect);
+        // exclude the WeightCode getter from results
+        $foo->shouldReceive('getHidden')->andReturn(['WeightCode']);
+        $foo->weight = 10;
+        $foo->name = 'name';
+        $foo->added_at = '2017-10-11T00:00:00';
+        $foo->code = 'code';
+
+        $actual = $foo->metadata();
         $this->assertEquals($expected, $actual);
     }
 }


### PR DESCRIPTION
As Laravel allows you to exclude getters from serialisation, our metadata
processing needs to also do the same.  Previously, it was paying attention
for the actual table fields, but then blithely ignoring restrictions
for any defined getters - this can be problematic if, for example, you have
added a deprecation warning to a getter and app boot chokes on that.