### PR TITLE
Cache table column list retrievals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+   * Cache table field list lookups
    * Respect hidden/visible getters in metadata processing
    * Require property names to be case-insensitive unique
    * Fix bug that stopped migration attempts

--- a/tests/unit/Models/MetadataTraitExtractionTest.php
+++ b/tests/unit/Models/MetadataTraitExtractionTest.php
@@ -169,5 +169,7 @@ class MetadataTraitExtractionTest extends TestCase
 
         $actual = $foo->metadata();
         $this->assertEquals($expected, $actual);
+        $final = $foo->metadata();
+        $this->assertEquals($expected, $final);
     }
 }

--- a/tests/unit/Models/MetadataTraitTest.php
+++ b/tests/unit/Models/MetadataTraitTest.php
@@ -170,6 +170,7 @@ class MetadataTraitTest extends TestCase
         $foo = \Mockery::mock(TestGetterModel::class)->makePartial();
         $foo->shouldReceive('getweightAttribute')->andReturn(null);
         $foo->shouldReceive('getConnection')->andReturn($connect);
+        $foo->reset();
         $result = $foo->metadata();
         $this->assertEquals(count($expected), count($result));
         foreach ($expected as $key => $val) {
@@ -381,6 +382,7 @@ class MetadataTraitTest extends TestCase
 
         $foo = \Mockery::mock(TestGetterModel::class)->makePartial();
         $foo->shouldReceive('getConnection->getSchemaBuilder')->andReturn($mockBuilder);
+        $foo->reset();
 
         $result = $foo->metadataMask();
         $this->assertEquals(count($expected), count($result));


### PR DESCRIPTION
Previously, each model was retrieving its column list twice, separately,
each and every time during application boot, which unnecessarily slows
things up, especially when there's a large number of models to load.

Caching those lookups trims one DB lookup per model from the boot process,
in a simple time/space tradeoff.