### PR TITLE
Convert all primitive property default values to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+   * Unconditionally convert default primitive property values to strings
 
 0.3.1 (2017-11-09)
 ------------------

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -293,7 +293,7 @@ class MetadataProvider extends MetadataBaseProvider
                 $field->getName(),
                 $field->getEdmFieldType(),
                 $field->getFieldType() == EntityFieldType::PRIMITIVE_BAG(),
-                $field->getDefaultValue(),
+                strval($field->getDefaultValue()),
                 $field->getIsNullable()
             );
         }


### PR DESCRIPTION
Using strval($foo) means POData-Laravel can rely on whatever toString()
function is defined for the default value result, without having to
worry about the details.