### PR TITLE
Cut single entity retrieval over to method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
-  - php vendor/bin/coveralls --exclude-no-stmt
+  - php vendor/bin/php-coveralls --exclude-no-stmt
 
 after_success:
   - coveralls

--- a/src/Query/LaravelReadQuery.php
+++ b/src/Query/LaravelReadQuery.php
@@ -306,11 +306,11 @@ class LaravelReadQuery
 
         $propertyName = $targetProperty->getName();
         $propertyName = $this->getLaravelRelationName($propertyName);
-        $result = $sourceEntityInstance->$propertyName;
+        $result = $sourceEntityInstance->$propertyName()->first();
         if (null === $result) {
             return null;
         }
-        assert($result instanceof Model, get_class($result));
+        assert($result instanceof Model, 'Model not retrieved from Eloquent relation');
         if ($targetProperty->getResourceType()->getInstanceType()->getName() != get_class($result)) {
             return null;
         }

--- a/tests/unit/Query/LaravelQueryTest.php
+++ b/tests/unit/Query/LaravelQueryTest.php
@@ -733,14 +733,21 @@ class LaravelQueryTest extends TestCase
         $sourceEntity = \Mockery::mock(TestMorphManySource::class)->makePartial();
         $sourceEntity->shouldReceive('where')->andReturnSelf();
         $sourceEntity->shouldReceive('orderBy')->andReturnSelf();
-        $sourceEntity->shouldReceive('getAttribute')->withArgs(['morphTarget'])->andReturnSelf()->once();
-        $sourceEntity->shouldReceive('get')->andReturn(collect(['a']))->once();
+        $sourceEntity->shouldReceive('morphTarget')->andReturnSelf()->once();
+        $sourceEntity->shouldReceive('first')->andReturn('a')->once();
         $property->shouldReceive('getResourceType->getInstanceType->getName')->andReturn(get_class($sourceEntity));
 
         $foo = new LaravelQuery();
 
-        $result = $foo->getRelatedResourceReference($srcResource, $sourceEntity, $dstResource, $property);
-        $this->assertEquals('a', $result->get()->first());
+        $expected = 'assert(): Model not retrieved from Eloquent relation failed';
+        $actual = null;
+
+        try {
+            $result = $foo->getRelatedResourceReference($srcResource, $sourceEntity, $dstResource, $property);
+        } catch (\ErrorException $e) {
+            $actual = $e->getMessage();
+        }
+        $this->assertEquals($expected, $actual);
     }
 
     public function testGetRelatedResourceReferenceWithValidGubbins()
@@ -748,8 +755,8 @@ class LaravelQueryTest extends TestCase
         $mod1 = new TestModel();
         $mod1->name = 'Hammer, MC';
 
-        $model = new TestModel();
-        $model->name = $mod1;
+        $model = m::mock(TestModel::class)->makePartial();
+        $model->shouldReceive('name->first')->andReturn($mod1);
 
         $source = m::mock(ResourceSet::class);
         $targ = m::mock(ResourceSet::class);
@@ -759,7 +766,7 @@ class LaravelQueryTest extends TestCase
 
         $foo = new LaravelQuery();
         $result = $foo->getRelatedResourceReference($source, $model, $targ, $property);
-        $this->assertEquals($model->name, $result);
+        $this->assertEquals($mod1->name, $result->name);
     }
 
     public function testGetRelatedResourceReferenceWithInValidGubbins()
@@ -767,8 +774,8 @@ class LaravelQueryTest extends TestCase
         $mod1 = new TestModel();
         $mod1->name = 'Hammer, MC';
 
-        $model = new TestModel();
-        $model->name = $mod1;
+        $model = m::mock(TestModel::class)->makePartial();
+        $model->shouldReceive('name->first')->andReturn($mod1);
 
         $source = m::mock(ResourceSet::class);
         $targ = m::mock(ResourceSet::class);
@@ -786,8 +793,8 @@ class LaravelQueryTest extends TestCase
         $mod1 = new TestModel();
         $mod1->name = 'Hammer, MC';
 
-        $model = new TestModel();
-        $model->name = $mod1;
+        $model = m::mock(TestModel::class)->makePartial();
+        $model->shouldReceive('noname->first')->andReturn(null);
 
         $source = m::mock(ResourceSet::class);
         $targ = m::mock(ResourceSet::class);

--- a/tests/unit/Query/LaravelReadQueryTest.php
+++ b/tests/unit/Query/LaravelReadQueryTest.php
@@ -202,7 +202,7 @@ class LaravelReadQueryTest extends TestCase
         $foo->shouldReceive('getAuth->canAuth')->andReturn(true)->once();
 
         $rel = m::mock(HasOne::class)->makePartial();
-        $rel->shouldReceive('getResults')->andReturn(null)->once();
+        $rel->shouldReceive('first')->andReturn(null)->once();
 
         $entity = m::mock(TestMonomorphicSource::class)->makePartial();
         $entity->shouldReceive('oneSource')->andReturn($rel)->once();


### PR DESCRIPTION
Both @c-harris and I were having problems in local use retrieving models on other end of belongsTo relations, and this change seems to ensure all such relations get chased down when expanding a property off a resource set, rather than only first-in-best-dressed.