### PR TITLE
Disambiguate key descriptor processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ----------
+   * Make key-descriptor columns unambiguous when processed on models
    * Flatten residual references to PrimaryKey alias field
    * Handle batch processing requests
    * Annotate EntityGubbins failures with supplied class name

--- a/src/Query/LaravelReadQuery.php
+++ b/src/Query/LaravelReadQuery.php
@@ -401,9 +401,10 @@ class LaravelReadQuery
     private function processKeyDescriptor(&$sourceEntityInstance, KeyDescriptor $keyDescriptor = null)
     {
         if ($keyDescriptor) {
+            $table = ($sourceEntityInstance instanceof Model) ? $sourceEntityInstance->getTable().'.' : '';
             foreach ($keyDescriptor->getValidatedNamedValues() as $key => $value) {
                 $trimValue = trim($value[0], '\'');
-                $sourceEntityInstance = $sourceEntityInstance->where($key, $trimValue);
+                $sourceEntityInstance = $sourceEntityInstance->where($table.$key, $trimValue);
             }
         }
     }


### PR DESCRIPTION
When tables are joined, there's a risk of columns, especially commonly-occuring ones, turning up in at least two tables and thus being ambiguous.  This pull request, when processing a KeyDescriptor against an Eloquent model, explicitly and forcibly disambiguates any where clauses it adds to said model.

In no-join case, things proceed as they are now.  In join case, ambiguity has been removed.