### PR TITLE
Improve integration and fix request

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "laravel/framework": ">=5.1.11",
         "illuminate/http": ">=5.1.11",
         "voku/anti-xss": "2.1.*",
-        "symfony/yaml": "^3.4"
+        "symfony/yaml": "^2.7"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "php": ">=5.6.4",
         "laravel/framework": ">=5.1.11",
         "illuminate/http": ">=5.1.11",
-        "voku/anti-xss": "2.1.*"
+        "voku/anti-xss": "2.1.*",
+        "symfony/yaml": "^4.1"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "laravel/framework": ">=5.1.11",
         "illuminate/http": ">=5.1.11",
         "voku/anti-xss": "2.1.*",
-        "symfony/yaml": "^4.1"
+        "symfony/yaml": "^3.4"
     },
     "require-dev": {
         "mockery/mockery": "dev-master",

--- a/src/Controllers/ODataController.php
+++ b/src/Controllers/ODataController.php
@@ -78,7 +78,6 @@ class ODataController extends BaseController
             $responseCode = $headers[\POData\Common\ODataConstants::HTTPRESPONSE_HEADER_STATUS_CODE];
             $responseCode = isset($responseCode) ? intval($responseCode) : 200;
             $response = new Response($content, $responseCode);
-            $response->setStatusCode($headers['Status']);
 
             foreach ($headers as $headerName => $headerValue) {
                 if (null !== $headerValue) {

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -39,6 +39,12 @@ trait MetadataTrait
     {
         assert($this instanceof Model, get_class($this));
 
+        if (0 !== count(self::$tableData)) {
+            return self::$tableData;
+        } elseif (isset($this->odata)) {
+            return self::$tableData = $this->odata;
+        }
+
         // Break these out separately to enable separate reuse
         $connect = $this->getConnection();
         $builder = $connect->getSchemaBuilder();
@@ -46,10 +52,7 @@ trait MetadataTrait
         $table = $this->getTable();
 
         if (!$builder->hasTable($table)) {
-            return [];
-        }
-        if (0 !== count(self::$tableData)) {
-            return self::$tableData;
+            return self::$tableData = [];
         }
 
         $columns = $this->getTableColumns();

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -311,7 +311,11 @@ class MetadataProvider extends MetadataBaseProvider
     {
         $classes = $this->getClassMap();
         $ends = [];
-        $startName = $this->app->getNamespace();
+        try {
+            $startName = App::getNamespace();
+        } catch (\Exception $e) {
+            $startName = defined('PODATA_LARAVEL_APP_ROOT_NAMESPACE') ? PODATA_LARAVEL_APP_ROOT_NAMESPACE : 'App';
+        }
         foreach ($classes as $name) {
             if (\Illuminate\Support\Str::startsWith($name, $startName)) {
                 if (in_array('AlgoWeb\\PODataLaravel\\Models\\MetadataTrait', class_uses($name)) &&

--- a/src/Providers/MetadataProvider.php
+++ b/src/Providers/MetadataProvider.php
@@ -311,7 +311,7 @@ class MetadataProvider extends MetadataBaseProvider
     {
         $classes = $this->getClassMap();
         $ends = [];
-        $startName = defined('PODATA_LARAVEL_APP_ROOT_NAMESPACE') ? PODATA_LARAVEL_APP_ROOT_NAMESPACE : 'App';
+        $startName = $this->app->getNamespace();
         foreach ($classes as $name) {
             if (\Illuminate\Support\Str::startsWith($name, $startName)) {
                 if (in_array('AlgoWeb\\PODataLaravel\\Models\\MetadataTrait', class_uses($name)) &&

--- a/tests/TestExplicitModel.php
+++ b/tests/TestExplicitModel.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AlgoWeb\PODataLaravel\Models;
+
+use AlgoWeb\PODataLaravel\Models\MetadataTrait;
+use Illuminate\Database\Eloquent\Model as Model;
+use AlgoWeb\PODataLaravel\Models\ObjectMap\Entities\EntityFieldPrimitiveType;
+
+class TestExplicitModel extends Model
+{
+    use MetadataTrait;
+
+    protected $odata = [
+        'id' => [
+            'type' => EntityFieldPrimitiveType::INTEGER,
+            'nullable' => false,
+            'fillable' => false,
+            'default' => null,
+        ],
+        'name' => [
+            'type' => EntityFieldPrimitiveType::STRING,
+            'nullable' => false,
+            'fillable' => true,
+            'default' => null,
+        ],
+    ];
+}

--- a/tests/unit/Models/MetadataTraitTest.php
+++ b/tests/unit/Models/MetadataTraitTest.php
@@ -178,6 +178,20 @@ class MetadataTraitTest extends TestCase
         }
     }
 
+    public function testMetadataGenerationFromExplicitModel()
+    {
+        $expected = [];
+        $expected['id'] = ['type' => 'integer', 'nullable' => false, 'fillable' => false, 'default' => null];
+        $expected['name'] = ['type' => 'string', 'nullable' => false, 'fillable' => true, 'default' => null];
+
+        $foo = new TestExplicitModel();
+        $result = $foo->metadata();
+        $this->assertEquals(count($expected), count($result));
+        foreach ($expected as $key => $val) {
+            $this->assertTrue($val === $result[$key]);
+        }
+    }
+
     /**
      * @covers \AlgoWeb\PODataLaravel\Models\MetadataTrait::metadataMask
      */


### PR DESCRIPTION
I have tried using this library and there are a couple of things that could be improved, in particular the following:
- Allow eloquent models to define metadata explicitly (I am working with mongodb, so the current implementation of inferring fields from column names is not appropiate, since mongo does not have a rigid structure).
- There is a helper method in laravel's Application class to detect the app namespace, so using the `PODATA_LARAVEL_APP_ROOT_NAMESPACE` constant is not necessary. Other than this, Laravel's convention is to use config files and env variables instead of php constants, so that could also be improved in the future.

Other than those improvements above, which you are free to accept or not, there are a couple of fixes as well that I think are critical because they break the integration. Those two are:
- Requiring symfony/yaml dependency (which is not required by laravel at the moment, so adding this package to an empty Laravel app breaks due to a missing dependency).
- Setting status code in ODataController class. The current implementation is calling the `setStatusCode` method incorrectly with a string, breaking the code at runtime since that method only accepts integers. In fact that same status code is already being passed correctly on the previous line when calling the constructor, so that line is entirely unecessary. Maybe in previous versions of Laravel this was working, but on the current version of Laravel 5.6 that code breaks.