### PR TITLE
Fix filter application (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
    * Fix up test infrastructure - it had rotted somewhat
+   * Wring out plain filtering
+     - Thank you to bgoak for finding this and helping to fix it
 
 0.3.5 (2018-07-17)
 ------------------

--- a/src/Models/MetadataTrait.php
+++ b/src/Models/MetadataTrait.php
@@ -78,7 +78,7 @@ trait MetadataTrait
 
         foreach ($rawFoo as $key => $val) {
             // Work around glitch in Doctrine when reading from MariaDB which added ` characters to root key value
-            $key = trim($key, '`');
+            $key = trim($key, '`"');
             $foo[$key] = $val;
         }
 

--- a/src/Query/LaravelReadQuery.php
+++ b/src/Query/LaravelReadQuery.php
@@ -108,7 +108,7 @@ class LaravelReadQuery extends LaravelBaseQuery
         $isvalid = null;
         if (isset($filterInfo)) {
             $method = 'return ' . $filterInfo->getExpressionAsString() . ';';
-            $clln = '$' . $resourceSet->getResourceType()->getName();
+            $clln = $resourceSet->getResourceType()->getName();
             $isvalid = function ($inputD) use ($clln, $method) {
                 $$clln = $inputD;
                 return eval($method);

--- a/src/Query/LaravelReadQuery.php
+++ b/src/Query/LaravelReadQuery.php
@@ -514,7 +514,8 @@ class LaravelReadQuery extends LaravelBaseQuery
 
         if ($nullFilter) {
             // default no-filter case, palm processing off to database engine - is a lot faster
-            $resultSet = $sourceEntityInstance->skip($skip)->take($top)->with($rawLoad)->get();
+            $resultSet = $sourceEntityInstance->skip($skip)->take($top)->with($rawLoad)
+                ->get();
             $resultCount = $bulkSetCount;
         } elseif ($bigSet) {
             if (!(isset($isvalid))) {

--- a/src/Query/LaravelReadQuery.php
+++ b/src/Query/LaravelReadQuery.php
@@ -104,7 +104,7 @@ class LaravelReadQuery extends LaravelBaseQuery
             $top = PHP_INT_MAX;
         }
 
-        $nullFilter = true;
+        $nullFilter = !isset($filterInfo);
         $isvalid = null;
         if (isset($filterInfo)) {
             $method = 'return ' . $filterInfo->getExpressionAsString() . ';';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ namespace AlgoWeb\PODataLaravel\Models;
 use AlgoWeb\PODataLaravel\Kernels\ConsoleKernel;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Database\Query\Processors\Processor;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as BaseTestCase;
@@ -49,10 +50,14 @@ class TestCase extends BaseTestCase
         ]);
     }
 
-    protected function getBuilder(ConnectionInterface $conn = null)
+    protected function getBuilder(ConnectionInterface $conn = null, Processor $proc = null)
     {
         $grammar = new \Illuminate\Database\Query\Grammars\Grammar;
-        $processor = \Mockery::mock('Illuminate\Database\Query\Processors\Processor')->makePartial();
+        if (null !== $proc) {
+            $processor = $proc;
+        } else {
+            $processor = \Mockery::mock(Processor::class)->makePartial();
+        }
         if (null != $conn) {
             $connect = $conn;
         } else {


### PR DESCRIPTION
Due to a previous goof, filtering was effectively ignored.  This branch fixes up long-broken tests and stops filter parameters, if supplied, from being ignored.